### PR TITLE
Refactors extracted from email feature PR

### DIFF
--- a/src/components/ComponentPreview.tsx
+++ b/src/components/ComponentPreview.tsx
@@ -93,7 +93,9 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({component}) => {
   const componentType = component.type || 'OF_MISSING_TYPE';
   const PreviewComponent = REGISTRY?.[componentType]?.preview || Fallback;
   const defaultValue = REGISTRY?.[componentType]?.defaultValue || '';
-  const initialValues = {[component.key || '']: component.multiple ? [] : defaultValue};
+  const key = component.key || 'OF_MISSING_KEY';
+  const initialValues = {[key]: component.multiple ? [] : defaultValue};
+
   return (
     <ComponentPreviewWrapper component={component} initialValues={initialValues}>
       <PreviewComponent component={component} />

--- a/src/components/builder/prefill/prefill.stories.tsx
+++ b/src/components/builder/prefill/prefill.stories.tsx
@@ -1,7 +1,7 @@
 import withFormik from '@bbbtech/storybook-formik';
 import {expect} from '@storybook/jest';
 import {ComponentMeta, ComponentStory} from '@storybook/react';
-import {fireEvent, userEvent, waitFor, within} from '@storybook/testing-library';
+import {userEvent, waitFor, within} from '@storybook/testing-library';
 
 import {PrefillAttributeOption, PrefillConfiguration, PrefillPluginOption} from '.';
 

--- a/src/components/formio/component.tsx
+++ b/src/components/formio/component.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 
 import {useValidationErrors} from '@/utils/errors';
+import {ErrorList} from '@/utils/errors';
 
 import ComponentLabel from './component-label';
 
@@ -36,13 +37,7 @@ const Component: React.FC<ComponentProps> = ({
         <ComponentLabel label={label} required={required} htmlId={props.htmlId} tooltip={tooltip} />
       )}
       {children}
-      <div className="formio-errors invalid-feedback">
-        {errors.map((error, index) => (
-          <div key={index} className="form-text error">
-            {error}
-          </div>
-        ))}
-      </div>
+      <ErrorList errors={errors} />
     </div>
   );
 };

--- a/src/components/formio/textfield.tsx
+++ b/src/components/formio/textfield.tsx
@@ -4,7 +4,7 @@ import {useContext, useRef} from 'react';
 
 import {RenderContext} from '@/context';
 import CharCount from '@/utils/charcount';
-import {useValidationErrors} from '@/utils/errors';
+import {ErrorList, useValidationErrors} from '@/utils/errors';
 
 import Component from './component';
 import Description from './description';
@@ -31,7 +31,7 @@ export const TextField: React.FC<JSX.IntrinsicElements['input'] & TextFieldProps
   const {getFieldProps, getFieldMeta} = useFormikContext();
   const {value} = getFieldProps<string | undefined>(name);
   const {touched} = getFieldMeta<string | undefined>(name);
-  const {hasErrors} = useValidationErrors(name);
+  const {errors, hasErrors} = useValidationErrors(name);
   // const [{value}, {touched}] = useField<string | undefined>(name);
   const inputRef = useRef<HTMLInputElement>(null);
   const {bareInput} = useContext(RenderContext);
@@ -64,6 +64,7 @@ export const TextField: React.FC<JSX.IntrinsicElements['input'] & TextFieldProps
       <>
         {inputField}
         {charCount}
+        <ErrorList errors={errors} />
       </>
     );
   }

--- a/src/registry/index.tsx
+++ b/src/registry/index.tsx
@@ -1,7 +1,7 @@
 import {ExtendedComponentSchema} from 'formiojs';
 import React from 'react';
 import {IntlShape} from 'react-intl';
-import {ZodObject} from 'zod';
+import {z} from 'zod';
 
 import {ComponentPreviewProps} from '@/components/ComponentPreview';
 import {EditFormComponentSchema} from '@/types';
@@ -25,7 +25,7 @@ Fallback.defaultValues = {};
 interface Registry {
   [key: string]: {
     edit: EditFormDefinition<EditFormProps>;
-    editSchema: (intl: IntlShape) => ZodObject<{}>;
+    editSchema: (intl: IntlShape) => z.ZodFirstPartySchemaTypes;
     preview: React.FC<ComponentPreviewProps>;
     // textfield -> string, numberfield -> number etc. This is used for the formik
     // initial data

--- a/src/registry/textfield/edit-validation.ts
+++ b/src/registry/textfield/edit-validation.ts
@@ -1,57 +1,7 @@
 import {IntlShape} from 'react-intl';
-import {
-  ErrorMapCtx,
-  ZodErrorMap,
-  ZodInvalidStringIssue,
-  ZodIssueOptionalMessage,
-  object,
-  string,
-} from 'zod';
 
-const isInvalidStringIssue = (issue: ZodIssueOptionalMessage): issue is ZodInvalidStringIssue => {
-  return issue.code === 'invalid_string';
-};
+import {buildCommonSchema} from '@/registry/validation';
 
-type ErrorBuilder = (issue: ZodIssueOptionalMessage, ctx: ErrorMapCtx) => string | void;
-
-const getErrorMap = (builder: ErrorBuilder): ZodErrorMap => {
-  const errorMap = (issue: ZodIssueOptionalMessage, ctx: ErrorMapCtx) => {
-    const message = builder(issue, ctx);
-    if (message) {
-      return {message};
-    }
-    return {message: ctx.defaultError};
-  };
-  return errorMap;
-};
-
-const schema = (intl: IntlShape) => {
-  return object({
-    label: string({
-      errorMap: getErrorMap((issue, ctx) => {
-        const isRequiredError = issue.code === 'invalid_type' && ctx.data === undefined;
-        if (isRequiredError) {
-          return intl.formatMessage({
-            description: "Form builder label field 'required' validation error",
-            defaultMessage: 'Label is a required field.',
-          });
-        }
-        return;
-      }),
-    }),
-    key: string({
-      errorMap: getErrorMap(issue => {
-        if (isInvalidStringIssue(issue) && issue.validation === 'regex') {
-          return intl.formatMessage({
-            description: "Form builder 'key' pattern validation error",
-            defaultMessage:
-              'The property name must only contain alphanumeric characters, underscores, dots and dashes and should not be ended by dash or dot.',
-          });
-        }
-        return;
-      }),
-    }).regex(new RegExp('^(\\w|\\w[\\w-.]*\\w)$')),
-  });
-};
+const schema = (intl: IntlShape) => buildCommonSchema(intl);
 
 export default schema;

--- a/src/registry/validation.ts
+++ b/src/registry/validation.ts
@@ -1,0 +1,95 @@
+/**
+ * Zod schemas for builder form validation.
+ */
+import {IntlShape, defineMessages} from 'react-intl';
+import {z} from 'zod';
+
+/*
+  Validation message definitions.
+ */
+
+const DEFAULT_MESSAGES = defineMessages({
+  required: {
+    description: "Form builder label field 'required' validation error",
+    defaultMessage: 'Label is a required field.',
+  },
+  invalidKeyPattern: {
+    description: "Form builder 'key' pattern validation error",
+    defaultMessage:
+      'The property name must only contain alphanumeric characters, underscores, dots and dashes and should not be ended by dash or dot.',
+  },
+});
+
+/*
+Public API
+ */
+
+/**
+ * Construct the localised validation schema for the component.label property.
+ *
+ * Component label is (typically) a required text for Form.io components.
+ */
+export const buildLabelSchema = (intl: IntlShape): z.ZodString =>
+  z.string({
+    errorMap: getErrorMap((issue, ctx) => {
+      const isRequiredError = issue.code === 'invalid_type' && ctx.data === undefined;
+      if (isRequiredError) {
+        return intl.formatMessage(DEFAULT_MESSAGES.required);
+      }
+      return;
+    }),
+  });
+
+/**
+ * Construct the localised validation schema for the component.key property.
+ *
+ * The component key is used in the submission data and support lodash.get/set patterns.
+ * It must allow slug-characters, amended with underscores and dots for nested data
+ * lookups/setters. It may not end with a dash or dot for nested-data reasons.
+ */
+export const buildKeySchema = (intl: IntlShape): z.ZodString =>
+  z
+    .string({
+      errorMap: getErrorMap(issue => {
+        if (isInvalidStringIssue(issue) && issue.validation === 'regex') {
+          return intl.formatMessage(DEFAULT_MESSAGES.invalidKeyPattern);
+        }
+        return;
+      }),
+    })
+    .regex(new RegExp('^(\\w|\\w[\\w-.]*\\w)$'));
+
+/**
+ * Construct the localised validation schema shared by (most) Form.io components.
+ *
+ * You can use the output of this base schema with the `.and(...)` chain for additional
+ * component-type specific schema validations that are not/less generic in nature.
+ */
+export const buildCommonSchema = (intl: IntlShape) =>
+  z.object({
+    label: buildLabelSchema(intl),
+    key: buildKeySchema(intl),
+  });
+
+/*
+Helpers
+ */
+
+export const isInvalidStringIssue = (
+  issue: z.ZodIssueOptionalMessage
+): issue is z.ZodInvalidStringIssue => {
+  return issue.code === 'invalid_string';
+};
+
+type ErrorBuilder = (issue: z.ZodIssueOptionalMessage, ctx: z.ErrorMapCtx) => string | void;
+
+export const getErrorMap = (builder: ErrorBuilder): z.ZodErrorMap => {
+  const errorMap = (issue: z.ZodIssueOptionalMessage, ctx: z.ErrorMapCtx) => {
+    const message = builder(issue, ctx);
+    if (message) {
+      return {message};
+    }
+    return {message: ctx.defaultError};
+  };
+  return errorMap;
+};

--- a/src/utils/errors.tsx
+++ b/src/utils/errors.tsx
@@ -2,7 +2,7 @@ import {FormikErrors, useFormikContext} from 'formik';
 
 import {OpenFormsComponentSchemaBase} from '@/types';
 
-export const getErrorNames = <Values = unknown>(errors: FormikErrors<Values>): string[] => {
+export function getErrorNames<Values = unknown>(errors: FormikErrors<Values>): string[] {
   const names: string[] = [];
   Object.entries(errors).forEach(([key, nested]) => {
     // TODO: finish implementation
@@ -31,7 +31,7 @@ export const getErrorNames = <Values = unknown>(errors: FormikErrors<Values>): s
     }
   });
   return names;
-};
+}
 
 interface ValidationErrors {
   hasErrors: boolean;
@@ -47,3 +47,17 @@ export const useValidationErrors = (name: string): ValidationErrors => {
     errors,
   };
 };
+
+export interface ErrorListProps {
+  errors: string[];
+}
+
+export const ErrorList: React.FC<ErrorListProps> = ({errors}) => (
+  <div className="formio-errors invalid-feedback">
+    {errors.map((error, index) => (
+      <div key={index} className="form-text error">
+        {error}
+      </div>
+    ))}
+  </div>
+);


### PR DESCRIPTION
Extracted the refactor code from #17 so that don't have to duplicate work when adding the typescript types from https://github.com/open-formulieren/types in a follow up PR.