### PR TITLE
Add minimal edit-json mode to builder

### DIFF
--- a/src/components/ComponentEditForm.stories.tsx
+++ b/src/components/ComponentEditForm.stories.tsx
@@ -1,6 +1,6 @@
 import {expect} from '@storybook/jest';
 import {Meta, StoryFn, StoryObj} from '@storybook/react';
-import {userEvent, within} from '@storybook/testing-library';
+import {fireEvent, userEvent, within} from '@storybook/testing-library';
 
 import ComponentEditForm from './ComponentEditForm';
 
@@ -75,7 +75,9 @@ export const EditJSON: Story = {
 
     let componentJSON: any;
     await step('Open JSON edit', async () => {
-      await userEvent.click(canvas.getByText('Edit JSON'));
+      // https://github.com/testing-library/user-event/issues/1149 applies to radio and
+      // checkbox inputs
+      fireEvent.click(canvas.getByText('Edit JSON'));
       componentJSON = JSON.parse(
         canvas.getByLabelText<HTMLTextAreaElement>('Edit component JSON').value
       );

--- a/src/components/JSONEdit.tsx
+++ b/src/components/JSONEdit.tsx
@@ -1,0 +1,58 @@
+import clsx from 'clsx';
+import {useFormikContext} from 'formik';
+import {TextareaHTMLAttributes, useRef, useState} from 'react';
+
+interface JSONEditProps {
+  data: unknown; // JSON.stringify first argument has the 'any' type in TS itself...
+  className?: string;
+}
+
+const JSONEdit: React.FC<JSONEditProps & TextareaHTMLAttributes<HTMLTextAreaElement>> = ({
+  data,
+  className = 'form-control',
+  ...props
+}) => {
+  const dataAsJSON = JSON.stringify(data, null, 2);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const [value, setValue] = useState(dataAsJSON);
+  const [JSONValid, setJSONValid] = useState(true);
+  const {setValues} = useFormikContext();
+
+  // synchronize external state changes
+  const isFocused = inputRef.current == document.activeElement;
+  if (value != dataAsJSON && !isFocused) {
+    setValue(dataAsJSON);
+  }
+
+  const onChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const rawValue = event.target.value;
+    setValue(rawValue);
+
+    let updatedData: any;
+    try {
+      updatedData = JSON.parse(rawValue);
+      setJSONValid(true);
+    } catch {
+      setJSONValid(false);
+      return;
+    }
+    setValues(updatedData);
+  };
+  return (
+    <>
+      <textarea
+        ref={inputRef}
+        value={value}
+        className={clsx(className, {'is-invalid': !JSONValid})}
+        data-testid="jsonEdit"
+        onChange={onChange}
+        spellCheck={false}
+        {...props}
+      />
+      {!JSONValid && <div className="invalid-feedback">Could not parse the JSON.</div>}
+    </>
+  );
+};
+
+export default JSONEdit;


### PR DESCRIPTION
Closes #42

I don't know how to approach the autogenerated component key from the label :( It's tracked on the form field itself whether it was set manually or automatically, so the formik `setValues` doesn't know or has no way communicate that the key from the JSON should be taken.