### PR TITLE
Implement file component

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -141,7 +141,7 @@ export const DEFAULT_FILE_TYPES = [
   },
 ];
 
-const DEFAULT_DOCUMENT_TYPES: DocumentTypeOption[] = [
+export const DEFAULT_DOCUMENT_TYPES: DocumentTypeOption[] = [
   {
     backendLabel: '',
     catalogus: {
@@ -184,7 +184,7 @@ const DEFAULT_DOCUMENT_TYPES: DocumentTypeOption[] = [
   },
 ];
 
-const CONFIDENTIALITY_LEVELS = [
+export const CONFIDENTIALITY_LEVELS = [
   {label: 'Openbaar', value: 'openbaar'},
   {label: 'Beperkt openbaar', value: 'beperkt_openbaar'},
   {label: 'Intern', value: 'intern'},

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,11 +1,11 @@
 import type {StoryContext, StoryFn} from '@storybook/react';
 import {Formik} from 'formik';
-import React from 'react';
+
+import {BuilderContext, DocumentTypeOption} from '@/context';
 
 import {PrefillAttributeOption, PrefillPluginOption} from '../src/components/builder/prefill';
 import {RegistrationAttributeOption} from '../src/components/builder/registration/registration-attribute';
 import {ValidatorOption} from '../src/components/builder/validate/validator-select';
-import {BuilderContext} from '../src/context';
 
 export const ModalDecorator = (Story, {parameters}) => {
   if (parameters?.modal?.noModal) return <Story />;
@@ -141,6 +141,60 @@ export const DEFAULT_FILE_TYPES = [
   },
 ];
 
+const DEFAULT_DOCUMENT_TYPES: DocumentTypeOption[] = [
+  {
+    backendLabel: '',
+    catalogus: {
+      domein: 'VTH',
+    },
+    informatieobjecttype: {
+      url: 'https://example.com/iotype/123',
+      omschrijving: 'Vergunning',
+    },
+  },
+  {
+    backendLabel: 'Open Zaak',
+    catalogus: {
+      domein: 'VTH',
+    },
+    informatieobjecttype: {
+      url: 'https://example.com/iotype/456',
+      omschrijving: 'Vergunning',
+    },
+  },
+  {
+    backendLabel: 'Open Zaak',
+    catalogus: {
+      domein: 'VTH',
+    },
+    informatieobjecttype: {
+      url: 'https://example.com/iotype/789',
+      omschrijving: 'Ontheffing',
+    },
+  },
+  {
+    backendLabel: 'Open Zaak',
+    catalogus: {
+      domein: 'SOC',
+    },
+    informatieobjecttype: {
+      url: 'https://example.com/iotype/abc',
+      omschrijving: 'Aanvraag',
+    },
+  },
+];
+
+const CONFIDENTIALITY_LEVELS = [
+  {label: 'Openbaar', value: 'openbaar'},
+  {label: 'Beperkt openbaar', value: 'beperkt_openbaar'},
+  {label: 'Intern', value: 'intern'},
+  {label: 'Zaakvertrouwelijk', value: 'zaakvertrouwelijk'},
+  {label: 'Vertrouwelijk', value: 'vertrouwelijk'},
+  {label: 'Confidentieel', value: 'confidentieel'},
+  {label: 'Geheim', value: 'geheim'},
+  {label: 'Zeer geheim', value: 'zeer_geheim'},
+];
+
 function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -160,7 +214,8 @@ export const BuilderContextDecorator = (Story: StoryFn, context: StoryContext) =
   const defaultPrefillAttributes =
     context.parameters.builder?.defaultPrefillAttributes || DEFAULT_PREFILL_ATTRIBUTES;
   const defaultFileTypes = context.parameters.builder?.defaultFileTypes || DEFAULT_FILE_TYPES;
-
+  const defaultdocumentTypes =
+    context.parameters.builder?.defaultdocumentTypes || DEFAULT_DOCUMENT_TYPES;
   return (
     <BuilderContext.Provider
       value={{
@@ -189,6 +244,8 @@ export const BuilderContextDecorator = (Story: StoryFn, context: StoryContext) =
           return context?.args?.fileTypes || defaultFileTypes;
         },
         serverUploadLimit: '50MB',
+        getDocumentTypes: async () => context?.args?.documentTypes || defaultdocumentTypes,
+        getConfidentialityLevels: async () => CONFIDENTIALITY_LEVELS,
       }}
     >
       <Story />

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -68,6 +68,79 @@ const DEFAULT_PREFILL_ATTRIBUTES: {[key: string]: PrefillAttributeOption[]} = {
   ],
 };
 
+export const DEFAULT_FILE_TYPES = [
+  {
+    label: 'any filetype',
+    value: '*',
+  },
+  {
+    label: '.heic',
+    value: 'image/heic',
+  },
+  {
+    label: '.png',
+    value: 'image/png',
+  },
+  {
+    label: '.jpg',
+    value: 'image/jpeg',
+  },
+  {
+    label: '.pdf',
+    value: 'application/pdf',
+  },
+  {
+    label: '.xls',
+    value: 'application/vnd.ms-excel',
+  },
+  {
+    label: '.xlsx',
+    value: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  },
+  {
+    label: '.csv',
+    value: 'text/csv',
+  },
+  {
+    label: '.txt',
+    value: 'text/plain',
+  },
+  {
+    label: '.doc',
+    value: 'application/msword',
+  },
+  {
+    label: '.docx',
+    value: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  },
+  {
+    label: 'Open Office',
+    value:
+      'application/vnd.oasis.opendocument.*,application/vnd.stardivision.*,application/vnd.sun.xml.*',
+  },
+  {
+    label: '.zip',
+    value: 'application/zip',
+  },
+  {
+    label: '.rar',
+    value: 'application/vnd.rar',
+  },
+  {
+    label: '.tar',
+    value: 'application/x-tar',
+  },
+  {
+    label: '.msg',
+    value: 'application/vnd.ms-outlook',
+  },
+  {
+    label: '.dwg',
+    value:
+      'application/acad.dwg,application/autocad_dwg.dwg,application/dwg.dwg,application/x-acad.dwg,application/x-autocad.dwg,application/x-dwg.dwg,drawing/dwg.dwg,image/vnd.dwg,image/x-dwg.dwg',
+  },
+];
+
 function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -86,6 +159,8 @@ export const BuilderContextDecorator = (Story: StoryFn, context: StoryContext) =
     context.parameters.builder?.defaultPrefillPlugins || DEFAULT_PREFILL_PLUGINS;
   const defaultPrefillAttributes =
     context.parameters.builder?.defaultPrefillAttributes || DEFAULT_PREFILL_ATTRIBUTES;
+  const defaultFileTypes = context.parameters.builder?.defaultFileTypes || DEFAULT_FILE_TYPES;
+
   return (
     <BuilderContext.Provider
       value={{
@@ -110,6 +185,10 @@ export const BuilderContextDecorator = (Story: StoryFn, context: StoryContext) =
           const container = context?.args?.prefillAttributes || defaultPrefillAttributes;
           return container?.[plugin] || [{id: '', label: 'no plugins found'}];
         },
+        getFileTypes: async () => {
+          return context?.args?.fileTypes || defaultFileTypes;
+        },
+        serverUploadLimit: '50MB',
       }}
     >
       <Story />

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -9,6 +9,11 @@
     "description": "Remove component button",
     "originalDefault": "Remove"
   },
+  "+e1pgl": {
+    "defaultMessage": "Resize image",
+    "description": "Label for 'of.image.resize.apply' builder field",
+    "originalDefault": "Resize image"
+  },
   "+q3LGC": {
     "defaultMessage": "Regular Expression Pattern",
     "description": "Placeholder for 'validate.pattern' builder field",
@@ -44,15 +49,35 @@
     "description": "Label for 'delta.months' in relative delta date constraint validation",
     "originalDefault": "Months"
   },
+  "0gmZ4c": {
+    "defaultMessage": "Edit component JSON",
+    "description": "Accessible label for builder preview JSON edit field",
+    "originalDefault": "Edit component JSON"
+  },
+  "1Vvryq": {
+    "defaultMessage": "File name template",
+    "description": "Label for 'file.name' builder field",
+    "originalDefault": "File name template"
+  },
   "1WxO/D": {
     "defaultMessage": "Regular Expression Pattern",
     "description": "Label for 'validate.pattern' builder field",
     "originalDefault": "Regular Expression Pattern"
   },
+  "1pC7IP": {
+    "defaultMessage": "Specify template for name of uploaded file(s). <code>'{{ fileName }}'</code> contains the original filename.",
+    "description": "Tooltip for 'file.name' builder field",
+    "originalDefault": "Specify template for name of uploaded file(s). <code>'{{ fileName }}'</code> contains the original filename."
+  },
   "2/2h2C": {
     "defaultMessage": "The minimum value this field can have before the form can be submitted.",
     "description": "Tooltip for 'validate.min' builder field",
     "originalDefault": "The minimum value this field can have before the form can be submitted."
+  },
+  "2ajYIp": {
+    "defaultMessage": "Note that the server upload limit is {serverUploadLimit}.",
+    "description": "Description for 'fileMaxSize' builder field",
+    "originalDefault": "Note that the server upload limit is {serverUploadLimit}."
   },
   "2k+Mca": {
     "defaultMessage": "Validation",
@@ -99,6 +124,16 @@
     "description": "Label for 'delta.days' in relative delta date constraint validation",
     "originalDefault": "Days"
   },
+  "4HBnrF": {
+    "defaultMessage": "Drag or <browse>select</browse> files to upload.",
+    "description": "file component: drag/select files to upload text",
+    "originalDefault": "Drag or <browse>select</browse> files to upload."
+  },
+  "5/jkH9": {
+    "defaultMessage": "Specify a file size less than or equal to the server upload limit.",
+    "description": "File component 'fileMaxSize' greater than server limit",
+    "originalDefault": "Specify a file size less than or equal to the server upload limit."
+  },
   "5DyU8e": {
     "defaultMessage": "The maximum length requirement this field must meet.",
     "description": "Tooltip for 'validate.maxLength' builder field",
@@ -119,6 +154,11 @@
     "description": "Character count",
     "originalDefault": "{length} {length, plural, one {character} other {characters}}"
   },
+  "5y8Yt4": {
+    "defaultMessage": "Save the attachment in the Documents API with this InformatieObjectType. If unspecified, the registration plugin defaults are used.",
+    "description": "Tooltip for 'registration.informatieobjecttype' builder field",
+    "originalDefault": "Save the attachment in the Documents API with this InformatieObjectType. If unspecified, the registration plugin defaults are used."
+  },
   "5yP7G/": {
     "defaultMessage": "Maximum time",
     "description": "Label for 'validate.maxTime' builder field",
@@ -133,6 +173,11 @@
     "defaultMessage": "A required field must be filled in before the form can be submitted.",
     "description": "Tooltip for 'validate.required' builder field",
     "originalDefault": "A required field must be filled in before the form can be submitted."
+  },
+  "6XG2pL": {
+    "defaultMessage": "Confidentiality level",
+    "description": "Label for 'registration.docVertrouwelijkheidaanduiding' builder field",
+    "originalDefault": "Confidentiality level"
   },
   "7Ldfn+": {
     "defaultMessage": "Relative to variable",
@@ -174,6 +219,11 @@
     "description": "Simple conditional panel title",
     "originalDefault": "Simple conditional"
   },
+  "Ax7r1y": {
+    "defaultMessage": "File types",
+    "description": "Label for 'file.type' builder field",
+    "originalDefault": "File types"
+  },
   "B1ONuu": {
     "defaultMessage": "Location",
     "description": "Translations: location column header",
@@ -193,6 +243,11 @@
     "defaultMessage": "Maximum length",
     "description": "Placeholder for 'validate.maxLength' builder field",
     "originalDefault": "Maximum length"
+  },
+  "CG/va1": {
+    "defaultMessage": "Maximum file size",
+    "description": "Label for 'fileMaxSize' builder field",
+    "originalDefault": "Maximum file size"
   },
   "CRN74c": {
     "defaultMessage": "Placeholder",
@@ -284,10 +339,20 @@
     "description": "Component 'JSON' preview mode",
     "originalDefault": "JSON"
   },
+  "JnAJoU": {
+    "defaultMessage": "Use globally configured filetypes",
+    "description": "Label for 'useConfigFiletypes' builder field",
+    "originalDefault": "Use globally configured filetypes"
+  },
   "JneaQM": {
     "defaultMessage": "Hidden",
     "description": "Label for 'Hidden' builder field",
     "originalDefault": "Hidden"
+  },
+  "KrJ+rN": {
+    "defaultMessage": "The maximum number of files that can be uploaded.",
+    "description": "Tooltip for 'maxNumberOfFiles' builder field",
+    "originalDefault": "The maximum number of files that can be uploaded."
   },
   "Nsifca": {
     "defaultMessage": "The maximum date that can be picked.",
@@ -314,6 +379,11 @@
     "description": "Invalid email address format validation error",
     "originalDefault": "{field} must be a valid email."
   },
+  "QW32Dd": {
+    "defaultMessage": "Specify a positive, non-zero file size without decimals, e.g. 10MB.",
+    "description": "File component 'fileMaxSize' validation error",
+    "originalDefault": "Specify a positive, non-zero file size without decimals, e.g. 10MB."
+  },
   "Qjl92W": {
     "defaultMessage": "Preview",
     "description": "Component preview card title",
@@ -329,10 +399,20 @@
     "description": "Label identifier role main",
     "originalDefault": "Main"
   },
+  "RxmRzd": {
+    "defaultMessage": "When this is checked, the filetypes configured in the global settings will be used.",
+    "description": "Tooltip for 'useConfigFiletypes' builder field",
+    "originalDefault": "When this is checked, the filetypes configured in the global settings will be used."
+  },
   "SEXqhC": {
     "defaultMessage": "Mode preset",
     "description": "Label for 'date constraint mode' builder field",
     "originalDefault": "Mode preset"
+  },
+  "SEu4I2": {
+    "defaultMessage": "Title",
+    "description": "Label for 'registration.titel' builder field",
+    "originalDefault": "Title"
   },
   "SH67gH": {
     "defaultMessage": "In the future",
@@ -368,6 +448,11 @@
     "defaultMessage": "Postcode component",
     "description": "Label for 'derivePostcode' builder field",
     "originalDefault": "Postcode component"
+  },
+  "UxTJsK": {
+    "defaultMessage": "File",
+    "description": "Component edit form tab title for 'File' tab",
+    "originalDefault": "File"
   },
   "V6ClU9": {
     "defaultMessage": "If the postcode and house number are entered this field will autofill with the city",
@@ -414,6 +499,21 @@
     "description": "Tooltip for 'prefill.identifierRole' builder field",
     "originalDefault": "In case that multiple identifiers are returned (in the case of eHerkenning bewindvoering and DigiD Machtigen), should the prefill data related to the main identifier be used, or that related to the authorised person?"
   },
+  "XXRiTx": {
+    "defaultMessage": "File name",
+    "description": "file component preview: file name column header",
+    "originalDefault": "File name"
+  },
+  "Y4oNhH": {
+    "defaultMessage": "Maximum width",
+    "description": "Label for 'of.image.resize.width' builder field",
+    "originalDefault": "Maximum width"
+  },
+  "Y8cmP1": {
+    "defaultMessage": "Size",
+    "description": "file component preview: file size column header",
+    "originalDefault": "Size"
+  },
   "YBY95E": {
     "defaultMessage": "Manual",
     "description": "Link to manual title",
@@ -428,6 +528,11 @@
     "defaultMessage": "Select the plugin to use for the prefill functionality.",
     "description": "Tooltip for 'prefill.plugin' builder field",
     "originalDefault": "Select the plugin to use for the prefill functionality."
+  },
+  "aBADYT": {
+    "defaultMessage": "Maximum number of files",
+    "description": "Label for 'maxNumberOfFiles' builder field",
+    "originalDefault": "Maximum number of files"
   },
   "asZV7t": {
     "defaultMessage": "Derive street name",
@@ -473,6 +578,11 @@
     "defaultMessage": "Plugin",
     "description": "Label for 'prefill.plugin' builder field",
     "originalDefault": "Plugin"
+  },
+  "ctoEdl": {
+    "defaultMessage": "The name under which the INFORMATIEOBJECT is formally known.",
+    "description": "Tooltip for 'registration.titel' builder field",
+    "originalDefault": "The name under which the INFORMATIEOBJECT is formally known."
   },
   "czUDSQ": {
     "defaultMessage": "A short indicator that can provide more context for the expected field value. The '<sup> and <sub>' HTML tags are supported.",
@@ -529,6 +639,16 @@
     "description": "Tooltip for 'registration.attribute' builder field",
     "originalDefault": "Save the value as this attribute in the registration backend system."
   },
+  "fX5VwA": {
+    "defaultMessage": "The maximum size of a single file to upload.",
+    "description": "Tooltip for 'fileMaxSize' builder field",
+    "originalDefault": "The maximum size of a single file to upload."
+  },
+  "fY/8xt": {
+    "defaultMessage": "Information object type",
+    "description": "Label for 'registration.informatieobjecttype' builder field",
+    "originalDefault": "Information object type"
+  },
   "h0B9Fr": {
     "defaultMessage": "The property name must only contain alphanumeric characters, underscores, dots and dashes and should not be ended by dash or dot.",
     "description": "Form builder 'key' pattern validation error",
@@ -538,6 +658,11 @@
     "defaultMessage": "Form",
     "description": "Component 'Rich' preview mode",
     "originalDefault": "Form"
+  },
+  "hduHvs": {
+    "defaultMessage": "(optional)",
+    "description": "placeholder for 'file.name' builder field",
+    "originalDefault": "(optional)"
   },
   "iOADkJ": {
     "defaultMessage": "Show in summary",
@@ -604,6 +729,16 @@
     "description": "Tooltip for 'operator' in relative delta date constraint validation",
     "originalDefault": "Specify whether to add or subtract a time delta to/from the variable."
   },
+  "n9T2Oy": {
+    "defaultMessage": "When this is checked, any uploaded image(s) will be resized.",
+    "description": "Tooltip for 'of.image.resize.apply' builder field",
+    "originalDefault": "When this is checked, any uploaded image(s) will be resized."
+  },
+  "nW5g1S": {
+    "defaultMessage": "Bronorganisatie",
+    "description": "Label for 'registration.bronorganisatie' builder field",
+    "originalDefault": "Bronorganisatie"
+  },
   "nqJbi9": {
     "defaultMessage": "Tooltip",
     "description": "Component property 'Tooltip' label",
@@ -659,6 +794,11 @@
     "description": "Title of validation error translations panel",
     "originalDefault": "Custom error messages"
   },
+  "vlY36U": {
+    "defaultMessage": "Indication of the level to which extent the INFORMATIEOBJECT is meant to be public.",
+    "description": "Tooltip for 'registration.docVertrouwelijkheidaanduiding' builder field",
+    "originalDefault": "Indication of the level to which extent the INFORMATIEOBJECT is meant to be public."
+  },
   "vzhWgR": {
     "defaultMessage": "Specify the attribute holding the pre-fill data.",
     "description": "Tooltip for 'prefill.attribute' builder field",
@@ -674,6 +814,11 @@
     "description": "Label for 'operator' in relative delta date constraint validation",
     "originalDefault": "Add/subtract duration"
   },
+  "xnRkUj": {
+    "defaultMessage": "Edit JSON",
+    "description": "Component 'editJSON' preview mode",
+    "originalDefault": "Edit JSON"
+  },
   "yD4X2y": {
     "defaultMessage": "Maximum length",
     "description": "Label for 'validate.maxLength' builder field",
@@ -684,9 +829,19 @@
     "description": "Translations: translation column header",
     "originalDefault": "Translations"
   },
+  "yQUV3M": {
+    "defaultMessage": "RSIN of the organization which creates the ENKELVOUDIGINFORMATIEOBJECT.",
+    "description": "Tooltip for 'registration.bronorganisatie' builder field",
+    "originalDefault": "RSIN of the organization which creates the ENKELVOUDIGINFORMATIEOBJECT."
+  },
   "yQtFln": {
     "defaultMessage": "Hide a field from the form.",
     "description": "Tooltip for 'Hidden' builder field",
     "originalDefault": "Hide a field from the form."
+  },
+  "yujuQr": {
+    "defaultMessage": "Maximum height",
+    "description": "Label for 'of.image.resize.height' builder field",
+    "originalDefault": "Maximum height"
   }
 }

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -9,6 +9,11 @@
     "description": "Remove component button",
     "originalDefault": "Remove"
   },
+  "+e1pgl": {
+    "defaultMessage": "Afbeeldingsformaat wijzigen",
+    "description": "Label for 'of.image.resize.apply' builder field",
+    "originalDefault": "Resize image"
+  },
   "+q3LGC": {
     "defaultMessage": "Reguliere expressie",
     "description": "Placeholder for 'validate.pattern' builder field",
@@ -44,15 +49,35 @@
     "description": "Label for 'delta.months' in relative delta date constraint validation",
     "originalDefault": "Months"
   },
+  "0gmZ4c": {
+    "defaultMessage": "Component-JSON aanpassen",
+    "description": "Accessible label for builder preview JSON edit field",
+    "originalDefault": "Edit component JSON"
+  },
+  "1Vvryq": {
+    "defaultMessage": "Bestandsnaam",
+    "description": "Label for 'file.name' builder field",
+    "originalDefault": "File name template"
+  },
   "1WxO/D": {
     "defaultMessage": "Reguliere expressie",
     "description": "Label for 'validate.pattern' builder field",
     "originalDefault": "Regular Expression Pattern"
   },
+  "1pC7IP": {
+    "defaultMessage": "Specifieer een template voor de naam van het/de ge\u00fcploade bestand(en). <code>'{{ fileName }}'</code> bevat de oorspronkelijke bestandsnaam.",
+    "description": "Tooltip for 'file.name' builder field",
+    "originalDefault": "Specify template for name of uploaded file(s). <code>'{{ fileName }}'</code> contains the original filename."
+  },
   "2/2h2C": {
     "defaultMessage": "De minimale waarde die dit veld kan hebben voordat het formulier kan worden verzonden.",
     "description": "Tooltip for 'validate.min' builder field",
     "originalDefault": "The minimum value this field can have before the form can be submitted."
+  },
+  "2ajYIp": {
+    "defaultMessage": "Merk op dat de maximale uploadgrootte op de server {serverUploadLimit} is.",
+    "description": "Description for 'fileMaxSize' builder field",
+    "originalDefault": "Note that the server upload limit is {serverUploadLimit}."
   },
   "2k+Mca": {
     "defaultMessage": "Validatie",
@@ -99,6 +124,16 @@
     "description": "Label for 'delta.days' in relative delta date constraint validation",
     "originalDefault": "Days"
   },
+  "4HBnrF": {
+    "defaultMessage": "Sleep of <browse>selecteer</browse> bestanden om te uploaden.",
+    "description": "file component: drag/select files to upload text",
+    "originalDefault": "Drag or <browse>select</browse> files to upload."
+  },
+  "5/jkH9": {
+    "defaultMessage": "De maximale bestandsgrootte moet gelijk aan of kleiner dan de serverlimiet zijn.",
+    "description": "File component 'fileMaxSize' greater than server limit",
+    "originalDefault": "Specify a file size less than or equal to the server upload limit."
+  },
   "5DyU8e": {
     "defaultMessage": "De maximale toegestane lengte voor dit veld.",
     "description": "Tooltip for 'validate.maxLength' builder field",
@@ -119,6 +154,11 @@
     "description": "Character count",
     "originalDefault": "{length} {length, plural, one {character} other {characters}}"
   },
+  "5y8Yt4": {
+    "defaultMessage": "Sla het bestand op in de Documenten API met dit documenttype. Indien leeg, dan worden algemene instellingen gebruikt.",
+    "description": "Tooltip for 'registration.informatieobjecttype' builder field",
+    "originalDefault": "Save the attachment in the Documents API with this InformatieObjectType. If unspecified, the registration plugin defaults are used."
+  },
   "5yP7G/": {
     "defaultMessage": "Maximale tijd",
     "description": "Label for 'validate.maxTime' builder field",
@@ -133,6 +173,11 @@
     "defaultMessage": "Een verplicht veld moet ingevuld worden voor het formulier verstuurd kan worden.",
     "description": "Tooltip for 'validate.required' builder field",
     "originalDefault": "A required field must be filled in before the form can be submitted."
+  },
+  "6XG2pL": {
+    "defaultMessage": "Vertrouwelijkheidaanduiding",
+    "description": "Label for 'registration.docVertrouwelijkheidaanduiding' builder field",
+    "originalDefault": "Confidentiality level"
   },
   "7Ldfn+": {
     "defaultMessage": "Ten opzichte van een variabele",
@@ -174,6 +219,11 @@
     "description": "Simple conditional panel title",
     "originalDefault": "Simple conditional"
   },
+  "Ax7r1y": {
+    "defaultMessage": "Bestandstypen",
+    "description": "Label for 'file.type' builder field",
+    "originalDefault": "File types"
+  },
   "B1ONuu": {
     "defaultMessage": "Locatie",
     "description": "Translations: location column header",
@@ -194,11 +244,16 @@
     "description": "Placeholder for 'validate.maxLength' builder field",
     "originalDefault": "Maximum length"
   },
+  "CG/va1": {
+    "defaultMessage": "Maximale bestandsgrootte",
+    "description": "Label for 'fileMaxSize' builder field",
+    "originalDefault": "Maximum file size"
+  },
   "CRN74c": {
     "defaultMessage": "Placeholder",
     "description": "Placeholder for 'placeholder' builder field",
-    "originalDefault": "Placeholder",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "Placeholder"
   },
   "D0hDzV": {
     "defaultMessage": "{componentType}-component",
@@ -213,8 +268,8 @@
   "Dm3S1P": {
     "defaultMessage": "Placeholder",
     "description": "Component property 'Placeholder' label",
-    "originalDefault": "Placeholder",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "Placeholder"
   },
   "Do20MZ": {
     "defaultMessage": "Basis",
@@ -284,13 +339,23 @@
   "JdwEl7": {
     "defaultMessage": "JSON",
     "description": "Component 'JSON' preview mode",
-    "originalDefault": "JSON",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "JSON"
+  },
+  "JnAJoU": {
+    "defaultMessage": "Gebruik algemene bestandstypeninstellingen",
+    "description": "Label for 'useConfigFiletypes' builder field",
+    "originalDefault": "Use globally configured filetypes"
   },
   "JneaQM": {
     "defaultMessage": "Verborgen",
     "description": "Label for 'Hidden' builder field",
     "originalDefault": "Hidden"
+  },
+  "KrJ+rN": {
+    "defaultMessage": "Het maximaal aantal bestanden die mogen geüpload worden.",
+    "description": "Tooltip for 'maxNumberOfFiles' builder field",
+    "originalDefault": "The maximum number of files that can be uploaded."
   },
   "Nsifca": {
     "defaultMessage": "De maximale datum die gekozen kan worden.",
@@ -305,8 +370,8 @@
   "OtGsP8": {
     "defaultMessage": "Label",
     "description": "Component property 'Label' label",
-    "originalDefault": "Label",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "Label"
   },
   "PhXIai": {
     "defaultMessage": "Aantal jaren. Lege waarden worden genegeerd.",
@@ -317,6 +382,11 @@
     "defaultMessage": "Ongeldig e-mailadres.",
     "description": "Invalid email address format validation error",
     "originalDefault": "{field} must be a valid email."
+  },
+  "QW32Dd": {
+    "defaultMessage": "Geef een bestandsgrootte groter dan nul zonder decimalen op, bijvoorbeeld '10MB'.",
+    "description": "File component 'fileMaxSize' validation error",
+    "originalDefault": "Specify a positive, non-zero file size without decimals, e.g. 10MB."
   },
   "Qjl92W": {
     "defaultMessage": "Voorbeeld",
@@ -333,10 +403,20 @@
     "description": "Label identifier role main",
     "originalDefault": "Main"
   },
+  "RxmRzd": {
+    "defaultMessage": "Indien ingeschakeld, gebruik dan de algemene instellingen voor toegestane bestandstypen.",
+    "description": "Tooltip for 'useConfigFiletypes' builder field",
+    "originalDefault": "When this is checked, the filetypes configured in the global settings will be used."
+  },
   "SEXqhC": {
     "defaultMessage": "Validatiemethode",
     "description": "Label for 'date constraint mode' builder field",
     "originalDefault": "Mode preset"
+  },
+  "SEu4I2": {
+    "defaultMessage": "Titel",
+    "description": "Label for 'registration.titel' builder field",
+    "originalDefault": "Title"
   },
   "SH67gH": {
     "defaultMessage": "In de toekomst",
@@ -356,8 +436,8 @@
   "UCGSib": {
     "defaultMessage": "Plugin(s)",
     "description": "Label for 'validate.plugins' builder field",
-    "originalDefault": "Plugin(s)",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "Plugin(s)"
   },
   "UGLnLd": {
     "defaultMessage": "Selecteer de plugin(s) om te gebruiken voor validatie.",
@@ -373,6 +453,11 @@
     "defaultMessage": "Postcodecomponent",
     "description": "Label for 'derivePostcode' builder field",
     "originalDefault": "Postcode component"
+  },
+  "UxTJsK": {
+    "defaultMessage": "Bestand",
+    "description": "Component edit form tab title for 'File' tab",
+    "originalDefault": "File"
   },
   "V6ClU9": {
     "defaultMessage": "Indien de postcode en huisnummer ingevuld zijn, dan wordt automatisch de stad ingevuld.",
@@ -419,6 +504,21 @@
     "description": "Tooltip for 'prefill.identifierRole' builder field",
     "originalDefault": "In case that multiple identifiers are returned (in the case of eHerkenning bewindvoering and DigiD Machtigen), should the prefill data related to the main identifier be used, or that related to the authorised person?"
   },
+  "XXRiTx": {
+    "defaultMessage": "Bestandsnaam",
+    "description": "file component preview: file name column header",
+    "originalDefault": "File name"
+  },
+  "Y4oNhH": {
+    "defaultMessage": "Maximale breedte",
+    "description": "Label for 'of.image.resize.width' builder field",
+    "originalDefault": "Maximum width"
+  },
+  "Y8cmP1": {
+    "defaultMessage": "Bestandsgrootte",
+    "description": "file component preview: file size column header",
+    "originalDefault": "Size"
+  },
   "YBY95E": {
     "defaultMessage": "Handleiding",
     "description": "Link to manual title",
@@ -433,6 +533,11 @@
     "defaultMessage": "Selecteer de plugin om te gebruiken voor prefill.",
     "description": "Tooltip for 'prefill.plugin' builder field",
     "originalDefault": "Select the plugin to use for the prefill functionality."
+  },
+  "aBADYT": {
+    "defaultMessage": "Maximum aantal bestanden",
+    "description": "Label for 'maxNumberOfFiles' builder field",
+    "originalDefault": "Maximum number of files"
   },
   "asZV7t": {
     "defaultMessage": "Straatnaam afleiden",
@@ -477,8 +582,13 @@
   "ce1N0I": {
     "defaultMessage": "Plugin",
     "description": "Label for 'prefill.plugin' builder field",
-    "originalDefault": "Plugin",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "Plugin"
+  },
+  "ctoEdl": {
+    "defaultMessage": "Titel voor het document in de Documenten API.",
+    "description": "Tooltip for 'registration.titel' builder field",
+    "originalDefault": "The name under which the INFORMATIEOBJECT is formally known."
   },
   "czUDSQ": {
     "defaultMessage": "Een korte beschrijvende indicatie die meer context beschrijft voor de verwachtte waarde. Je kan hier de '<sup> en <sub>' HTML tags gebruiken.",
@@ -528,13 +638,23 @@
   "fRMCJI": {
     "defaultMessage": "Prefill",
     "description": "Component edit form tab title for 'Prefill' tab",
-    "originalDefault": "Prefill",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "Prefill"
   },
   "fT6Gtt": {
     "defaultMessage": "Sla de waarde op onder het geselecteerde attribuut in de geselecteerde registratieplugin.",
     "description": "Tooltip for 'registration.attribute' builder field",
     "originalDefault": "Save the value as this attribute in the registration backend system."
+  },
+  "fX5VwA": {
+    "defaultMessage": "De maximale bestandsgrootte voor één enkele bestandsupload.",
+    "description": "Tooltip for 'fileMaxSize' builder field",
+    "originalDefault": "The maximum size of a single file to upload."
+  },
+  "fY/8xt": {
+    "defaultMessage": "Informatieobjecttype",
+    "description": "Label for 'registration.informatieobjecttype' builder field",
+    "originalDefault": "Information object type"
   },
   "h0B9Fr": {
     "defaultMessage": "De eigenschapsnaam mag alleen alfanumerieke tekens, onderstrepingstekens, punten en streepjes bevatten en mag niet worden afgesloten met een streepje of punt.",
@@ -545,6 +665,11 @@
     "defaultMessage": "Formulierveld",
     "description": "Component 'Rich' preview mode",
     "originalDefault": "Form"
+  },
+  "hduHvs": {
+    "defaultMessage": "(optioneel)",
+    "description": "placeholder for 'file.name' builder field",
+    "originalDefault": "(optional)"
   },
   "iOADkJ": {
     "defaultMessage": "Weergeven in overzicht",
@@ -611,11 +736,22 @@
     "description": "Tooltip for 'operator' in relative delta date constraint validation",
     "originalDefault": "Specify whether to add or subtract a time delta to/from the variable."
   },
+  "n9T2Oy": {
+    "defaultMessage": "Wanneer dit is ingeschakeld, dan wordt het afbeeldingsformaat gewijzigd.",
+    "description": "Tooltip for 'of.image.resize.apply' builder field",
+    "originalDefault": "When this is checked, any uploaded image(s) will be resized."
+  },
+  "nW5g1S": {
+    "defaultMessage": "Bronorganisatie",
+    "description": "Label for 'registration.bronorganisatie' builder field",
+    "isTranslated": true,
+    "originalDefault": "Bronorganisatie"
+  },
   "nqJbi9": {
     "defaultMessage": "Tooltip",
     "description": "Component property 'Tooltip' label",
-    "originalDefault": "Tooltip",
-    "isTranslated": true
+    "isTranslated": true,
+    "originalDefault": "Tooltip"
   },
   "oWJX5K": {
     "defaultMessage": "Suffix (bijv. m²)",
@@ -667,6 +803,11 @@
     "description": "Title of validation error translations panel",
     "originalDefault": "Custom error messages"
   },
+  "vlY36U": {
+    "defaultMessage": "Vertrouwelijkheidaanduiding van het document in de Documenten API. Indien leeg, dan worden algemene instellingen gebruikt.",
+    "description": "Tooltip for 'registration.docVertrouwelijkheidaanduiding' builder field",
+    "originalDefault": "Indication of the level to which extent the INFORMATIEOBJECT is meant to be public."
+  },
   "vzhWgR": {
     "defaultMessage": "Geef het attribuut op wat de prefill-gegevens bevat.",
     "description": "Tooltip for 'prefill.attribute' builder field",
@@ -682,6 +823,11 @@
     "description": "Label for 'operator' in relative delta date constraint validation",
     "originalDefault": "Add/subtract duration"
   },
+  "xnRkUj": {
+    "defaultMessage": "Wijzig JSON",
+    "description": "Component 'editJSON' preview mode",
+    "originalDefault": "Edit JSON"
+  },
   "yD4X2y": {
     "defaultMessage": "Maximale lengte",
     "description": "Label for 'validate.maxLength' builder field",
@@ -692,9 +838,19 @@
     "description": "Translations: translation column header",
     "originalDefault": "Translations"
   },
+  "yQUV3M": {
+    "defaultMessage": "RSIN van de organisatie die document registreert in de Documenten API. Indien leeg, dan worden algemene instellingen gebruikt.",
+    "description": "Tooltip for 'registration.bronorganisatie' builder field",
+    "originalDefault": "RSIN of the organization which creates the ENKELVOUDIGINFORMATIEOBJECT."
+  },
   "yQtFln": {
     "defaultMessage": "Verberg een veld in het formulier.",
     "description": "Tooltip for 'Hidden' builder field",
     "originalDefault": "Hide a field from the form."
+  },
+  "yujuQr": {
+    "defaultMessage": "Maximale hoogte",
+    "description": "Label for 'of.image.resize.height' builder field",
+    "originalDefault": "Maximum height"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@formatjs/cli": "^6.1.1",
         "@formatjs/ts-transformer": "^3.12.0",
         "@fortawesome/fontawesome-free": "^6.4.0",
-        "@open-formulieren/types": "^0.12.0",
+        "@open-formulieren/types": "^0.13.0",
         "@storybook/addon-actions": "^7.3.2",
         "@storybook/addon-essentials": "^7.3.2",
         "@storybook/addon-interactions": "^7.3.2",
@@ -5840,9 +5840,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.12.0.tgz",
-      "integrity": "sha512-JfS1XM9SI3mfM7RuO8Pdo5QaagnerIyRfsTfBX8N6zy6ujUoc0aMap8baJGH5/fMW8DwVo1xB1I45qPCj6LyCg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.13.0.tgz",
+      "integrity": "sha512-zG5eHaSqont3nSO2wzSO8fJL43E3pePbStenoISZuFR4dDV0sjdyUFwfmujZd0qgj089rJDE+MAZB3SwF4hZyg==",
       "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
@@ -35200,9 +35200,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.12.0.tgz",
-      "integrity": "sha512-JfS1XM9SI3mfM7RuO8Pdo5QaagnerIyRfsTfBX8N6zy6ujUoc0aMap8baJGH5/fMW8DwVo1xB1I45qPCj6LyCg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.13.0.tgz",
+      "integrity": "sha512-zG5eHaSqont3nSO2wzSO8fJL43E3pePbStenoISZuFR4dDV0sjdyUFwfmujZd0qgj089rJDE+MAZB3SwF4hZyg==",
       "dev": true
     },
     "@pkgjs/parseargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@formatjs/cli": "^6.1.1",
         "@formatjs/ts-transformer": "^3.12.0",
         "@fortawesome/fontawesome-free": "^6.4.0",
-        "@open-formulieren/types": "^0.11.0",
+        "@open-formulieren/types": "^0.12.0",
         "@storybook/addon-actions": "^7.3.2",
         "@storybook/addon-essentials": "^7.3.2",
         "@storybook/addon-interactions": "^7.3.2",
@@ -5840,9 +5840,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.11.0.tgz",
-      "integrity": "sha512-yQhxIfLTCTlb9+nIc/jzoa8tVpX2auT1TiU1QDc62A/tWQSqt4V9rBvgTQGhFedROYr3TggL4bGVV0kimv4tVg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.12.0.tgz",
+      "integrity": "sha512-JfS1XM9SI3mfM7RuO8Pdo5QaagnerIyRfsTfBX8N6zy6ujUoc0aMap8baJGH5/fMW8DwVo1xB1I45qPCj6LyCg==",
       "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
@@ -35200,9 +35200,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.11.0.tgz",
-      "integrity": "sha512-yQhxIfLTCTlb9+nIc/jzoa8tVpX2auT1TiU1QDc62A/tWQSqt4V9rBvgTQGhFedROYr3TggL4bGVV0kimv4tVg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.12.0.tgz",
+      "integrity": "sha512-JfS1XM9SI3mfM7RuO8Pdo5QaagnerIyRfsTfBX8N6zy6ujUoc0aMap8baJGH5/fMW8DwVo1xB1I45qPCj6LyCg==",
       "dev": true
     },
     "@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@formatjs/cli": "^6.1.1",
     "@formatjs/ts-transformer": "^3.12.0",
     "@fortawesome/fontawesome-free": "^6.4.0",
-    "@open-formulieren/types": "^0.12.0",
+    "@open-formulieren/types": "^0.13.0",
     "@storybook/addon-actions": "^7.3.2",
     "@storybook/addon-essentials": "^7.3.2",
     "@storybook/addon-interactions": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@formatjs/cli": "^6.1.1",
     "@formatjs/ts-transformer": "^3.12.0",
     "@fortawesome/fontawesome-free": "^6.4.0",
-    "@open-formulieren/types": "^0.11.0",
+    "@open-formulieren/types": "^0.12.0",
     "@storybook/addon-actions": "^7.3.2",
     "@storybook/addon-essentials": "^7.3.2",
     "@storybook/addon-interactions": "^7.3.2",

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -4,7 +4,11 @@ import {Meta, StoryFn, StoryObj} from '@storybook/react';
 import {fireEvent, userEvent, waitFor, within} from '@storybook/testing-library';
 import React from 'react';
 
-import {DEFAULT_FILE_TYPES} from '@/../.storybook/decorators';
+import {
+  CONFIDENTIALITY_LEVELS,
+  DEFAULT_DOCUMENT_TYPES,
+  DEFAULT_FILE_TYPES,
+} from '@/../.storybook/decorators';
 import {AnyComponentSchema} from '@/types';
 
 import ComponentConfiguration from './ComponentConfiguration';
@@ -116,6 +120,8 @@ const Template: StoryFn<TemplateArgs> = ({
     getPrefillAttributes={async (plugin: string) => prefillAttributes[plugin]}
     getFileTypes={async () => fileTypes}
     serverUploadLimit="50MB"
+    getDocumentTypes={async () => DEFAULT_DOCUMENT_TYPES}
+    getConfidentialityLevels={async () => CONFIDENTIALITY_LEVELS}
     component={component}
     isNew={isNew}
     builderInfo={builderInfo}

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -756,3 +756,33 @@ export const PhoneNumber: Story = {
     expect(args.onSubmit).toHaveBeenCalled();
   },
 };
+
+export const FileUpload: Story = {
+  render: Template,
+  name: 'type: file',
+
+  args: {
+    component: {
+      id: 'kiweljhr',
+      storage: 'url',
+      url: '',
+      type: 'file',
+      key: 'file',
+      label: 'A file upload',
+      file: {
+        name: '',
+        type: [],
+        allowedTypesLabels: [],
+      },
+      filePattern: '',
+    },
+
+    builderInfo: {
+      title: 'File upload',
+      icon: '',
+      group: 'file',
+      weight: 10,
+      schema: {},
+    },
+  },
+};

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -841,6 +841,8 @@ export const FileUpload: Story = {
       expect(args.onSubmit).toHaveBeenCalledWith({
         type: 'file',
         id: 'kiweljhr',
+        webcam: false,
+        options: {withCredentials: true},
         storage: 'url',
         url: '',
         // basic tab

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -792,7 +792,7 @@ export const FileUpload: Story = {
     },
   },
 
-  play: async ({canvasElement, step}) => {
+  play: async ({canvasElement, step, args}) => {
     const canvas = within(canvasElement);
 
     await step('Basic tab', async () => {
@@ -826,7 +826,69 @@ export const FileUpload: Story = {
         await expect(canvas.queryByText('any filetype')).toBeVisible();
       });
       await expect(canvas.queryByText('.pdf')).toBeVisible();
-      await userEvent.keyboard('[Escape]');
+      await userEvent.click(canvas.getByText('.jpg'));
+    });
+
+    await step('Submit configuration', async () => {
+      await userEvent.click(canvas.getByRole('button', {name: 'Save'}));
+      // See EditForm.defaultValues for the defaults
+      expect(args.onSubmit).toHaveBeenCalledWith({
+        type: 'file',
+        id: 'kiweljhr',
+        storage: 'url',
+        url: '',
+        // basic tab
+        label: 'A file upload',
+        key: 'aFileUpload',
+        description: '',
+        tooltip: '',
+        showInSummary: true,
+        showInEmail: false,
+        showInPDF: true,
+        multiple: false,
+        hidden: false,
+        clearOnHide: true,
+        isSensitiveData: true,
+        // Advanced tab
+        conditional: {
+          show: undefined,
+          when: '',
+          eq: '',
+        },
+        // Validation tab
+        validate: {
+          required: false,
+        },
+        translatedErrors: {
+          nl: {required: ''},
+        },
+        // file tab
+        file: {
+          name: '',
+          type: ['image/jpeg'],
+          allowedTypesLabels: ['.jpg'], // derived from file.type
+        },
+        filePattern: 'image/jpeg', // derived from file.type
+        useConfigFiletypes: false,
+        of: {
+          image: {
+            resize: {
+              apply: false,
+              width: 2000,
+              height: 2000,
+            },
+          },
+        },
+        fileMaxSize: '10MB',
+        maxNumberOfFiles: null,
+        // registration tab
+        registration: {
+          informatieobjecttype: '',
+          bronorganisatie: '',
+          docVertrouwelijkheidaanduiding: '',
+          titel: '',
+        },
+      });
     });
   },
 };

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -4,6 +4,7 @@ import {Meta, StoryFn, StoryObj} from '@storybook/react';
 import {fireEvent, userEvent, waitFor, within} from '@storybook/testing-library';
 import React from 'react';
 
+import {DEFAULT_FILE_TYPES} from '@/../.storybook/decorators';
 import {AnyComponentSchema} from '@/types';
 
 import ComponentConfiguration from './ComponentConfiguration';
@@ -50,6 +51,7 @@ export default {
       ],
     },
     supportedLanguageCodes: ['nl'],
+    fileTypes: DEFAULT_FILE_TYPES,
     translationsStore: {
       nl: {
         'A select': 'Een dropdown',
@@ -79,6 +81,7 @@ interface TemplateArgs {
   registrationAttributes: RegistrationAttributeOption[];
   prefillPlugins: PrefillPluginOption[];
   prefillAttributes: Record<string, PrefillAttributeOption[]>;
+  fileTypes: Array<{value: string; label: string}>;
   isNew: boolean;
   builderInfo: BuilderInfo;
   onCancel: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -95,6 +98,7 @@ const Template: StoryFn<TemplateArgs> = ({
   prefillAttributes,
   supportedLanguageCodes,
   translationsStore,
+  fileTypes,
   isNew,
   builderInfo,
   onCancel,
@@ -110,6 +114,8 @@ const Template: StoryFn<TemplateArgs> = ({
     getRegistrationAttributes={async () => registrationAttributes}
     getPrefillPlugins={async () => prefillPlugins}
     getPrefillAttributes={async (plugin: string) => prefillAttributes[plugin]}
+    getFileTypes={async () => fileTypes}
+    serverUploadLimit="50MB"
     component={component}
     isNew={isNew}
     builderInfo={builderInfo}
@@ -784,5 +790,11 @@ export const FileUpload: Story = {
       weight: 10,
       schema: {},
     },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('link', {name: 'File'}));
   },
 };

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -792,9 +792,41 @@ export const FileUpload: Story = {
     },
   },
 
-  play: async ({canvasElement}) => {
+  play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByRole('link', {name: 'File'}));
+    await step('Basic tab', async () => {
+      await expect(canvas.getByLabelText('Label')).toHaveValue('A file upload');
+      await waitFor(async () => {
+        await expect(canvas.getByLabelText('Property Name')).toHaveValue('aFileUpload');
+      });
+
+      await expect(canvas.getByLabelText('Description')).toHaveValue('');
+      await expect(canvas.getByLabelText('Tooltip')).toHaveValue('');
+      await expect(canvas.getByLabelText('Show in summary')).toBeChecked();
+      await expect(canvas.getByLabelText('Show in email')).not.toBeChecked();
+      await expect(canvas.getByLabelText('Show in PDF')).toBeChecked();
+
+      await expect(canvas.getByLabelText('Multiple values')).not.toBeChecked();
+      await expect(canvas.getByLabelText('Hidden')).not.toBeChecked();
+      await expect(canvas.getByLabelText('Clear on hide')).toBeChecked();
+      await expect(canvas.getByLabelText('Is sensitive data')).toBeChecked();
+    });
+
+    await step('File tab', async () => {
+      await userEvent.click(canvas.getByRole('link', {name: 'File'}));
+
+      await expect(canvas.getByLabelText('Maximum file size')).toHaveDisplayValue('10MB');
+      await expect(canvas.getByText('Note that the server upload limit is 50MB.')).toBeVisible();
+
+      // check that the file types are visible
+      canvas.getByLabelText('File types').focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await waitFor(async () => {
+        await expect(canvas.queryByText('any filetype')).toBeVisible();
+      });
+      await expect(canvas.queryByText('.pdf')).toBeVisible();
+      await userEvent.keyboard('[Escape]');
+    });
   },
 };

--- a/src/components/ComponentConfiguration.tsx
+++ b/src/components/ComponentConfiguration.tsx
@@ -31,6 +31,8 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
   getRegistrationAttributes,
   getPrefillPlugins,
   getPrefillAttributes,
+  getFileTypes,
+  serverUploadLimit,
   isNew,
   component,
   builderInfo,
@@ -48,6 +50,8 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
       getRegistrationAttributes,
       getPrefillPlugins,
       getPrefillAttributes,
+      getFileTypes,
+      serverUploadLimit,
     }}
   >
     <ComponentEditForm

--- a/src/components/ComponentConfiguration.tsx
+++ b/src/components/ComponentConfiguration.tsx
@@ -33,6 +33,8 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
   getPrefillAttributes,
   getFileTypes,
   serverUploadLimit,
+  getDocumentTypes,
+  getConfidentialityLevels,
   isNew,
   component,
   builderInfo,
@@ -52,6 +54,8 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
       getPrefillAttributes,
       getFileTypes,
       serverUploadLimit,
+      getDocumentTypes,
+      getConfidentialityLevels,
     }}
   >
     <ComponentEditForm

--- a/src/components/ComponentEditForm.tsx
+++ b/src/components/ComponentEditForm.tsx
@@ -2,9 +2,11 @@ import {Form, Formik} from 'formik';
 import {ExtendedComponentSchema} from 'formiojs/types/components/schema';
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
+import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {toFormikValidationSchema} from 'zod-formik-adapter';
 
+import {BuilderContext} from '@/context';
 import {Fallback, getRegistryEntry, isKnownComponentType} from '@/registry';
 import {AnyComponentSchema, FallbackSchema} from '@/types';
 
@@ -39,6 +41,7 @@ const ComponentEditForm: React.FC<ComponentEditFormProps> = ({
   onSubmit,
 }) => {
   const intl = useIntl();
+  const builderContext = useContext(BuilderContext);
 
   const registryEntry = getRegistryEntry(component);
   const {edit: EditForm, editSchema: zodSchema} = registryEntry;
@@ -65,7 +68,7 @@ const ComponentEditForm: React.FC<ComponentEditFormProps> = ({
         onSubmit(values);
         setSubmitting(false);
       }}
-      validationSchema={toFormikValidationSchema(zodSchema(intl))}
+      validationSchema={toFormikValidationSchema(zodSchema(intl, builderContext))}
     >
       {formik => {
         const component = formik.values;

--- a/src/components/ComponentPreview.stories.tsx
+++ b/src/components/ComponentPreview.stories.tsx
@@ -592,3 +592,26 @@ export const PhoneNumberMultiple: Story = {
     await expect(canvas.queryByTestId('input-phoneNumberPreview[1]')).not.toBeInTheDocument();
   },
 };
+
+export const File: Story = {
+  name: 'File upload',
+  render: Template,
+
+  args: {
+    component: {
+      type: 'file',
+      id: 'file',
+      key: 'filePreview',
+      label: 'File upload preview',
+      description: 'A preview of the file Formio component',
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // check that the user-controlled content is visible
+    await canvas.findByText('File upload preview');
+    await canvas.findByText('A preview of the file Formio component');
+  },
+};

--- a/src/components/builder/validate/validator-select.stories.tsx
+++ b/src/components/builder/validate/validator-select.stories.tsx
@@ -1,6 +1,6 @@
 import {expect} from '@storybook/jest';
 import {Meta, StoryFn, StoryObj} from '@storybook/react';
-import {userEvent, waitFor, within} from '@storybook/testing-library';
+import {userEvent, within} from '@storybook/testing-library';
 
 import {withFormik} from '@/sb-decorators';
 
@@ -27,7 +27,7 @@ export default {
       iframeHeight: 200,
     },
     modal: {noModal: true},
-    builder: {enableContext: true, validatorPluginsDelay: 100},
+    builder: {enableContext: true, validatorPluginsDelay: 500},
     formik: {initialValues: {validate: {plugins: []}}},
   },
   args: {
@@ -42,21 +42,22 @@ const Template: StoryFn<typeof ValidatorPluginSelect> = () => <ValidatorPluginSe
 export const Default: Story = {
   render: Template,
 
-  play: async ({canvasElement}) => {
+  play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
-    const input = await canvas.getByLabelText('Plugin(s)');
+    const input = canvas.getByLabelText('Plugin(s)');
 
     // open the dropdown
-    await input.focus();
+    input.focus();
     await userEvent.keyboard('[ArrowDown]');
 
-    await waitFor(async () => {
-      await expect(canvas.queryByText('Loading...')).toBeInTheDocument();
+    await step('Loading items from backend', async () => {
+      await expect(await canvas.findByText('Loading...')).toBeInTheDocument();
     });
-    // assert the options are present
-    await waitFor(async () => {
-      await expect(canvas.queryByText('Plugin 1')).toBeInTheDocument();
-      await expect(canvas.queryByText('Plugin 2')).toBeInTheDocument();
+
+    await step('Check available options displayed', async () => {
+      // assert the options are present
+      await expect(await canvas.findByText('Plugin 1')).toBeInTheDocument();
+      await expect(await canvas.findByText('Plugin 2')).toBeInTheDocument();
     });
   },
 };

--- a/src/components/formio/component.tsx
+++ b/src/components/formio/component.tsx
@@ -10,7 +10,7 @@ import ComponentLabel from './component-label';
 
 export interface ComponentProps {
   // XXX: eventually (most) of these literals will be included in AnyComponentType
-  type: AnyComponentSchema['type'] | 'checkbox' | 'datagrid' | 'datamap' | 'select';
+  type: AnyComponentSchema['type'] | 'checkbox' | 'datagrid' | 'datamap' | 'select' | 'columns';
   field?: string;
   required?: boolean;
   label?: React.ReactNode;

--- a/src/components/formio/description.tsx
+++ b/src/components/formio/description.tsx
@@ -1,5 +1,5 @@
 interface DescriptionProps {
-  text: string;
+  text: React.ReactNode;
 }
 
 const Description: React.FC<DescriptionProps> = ({text}) => {

--- a/src/components/formio/multiple.tsx
+++ b/src/components/formio/multiple.tsx
@@ -30,7 +30,7 @@ import Description from './description';
 */
 export interface CommonInputProps extends ComponentLabelProps {
   name: string;
-  description?: string;
+  description?: React.ReactNode;
 }
 
 export interface MultipleProps<P extends {}, T extends unknown> {

--- a/src/components/formio/textfield.tsx
+++ b/src/components/formio/textfield.tsx
@@ -16,7 +16,7 @@ export interface TextFieldProps {
   label?: React.ReactNode;
   required?: boolean;
   tooltip?: string;
-  description?: string;
+  description?: React.ReactNode;
   showCharCount?: boolean;
   inputMask?: string;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -35,6 +35,13 @@ export interface BuilderContextType {
   getRegistrationAttributes: (componentType: string) => Promise<RegistrationAttributeOption[]>;
   getPrefillPlugins: (componentType: string) => Promise<PrefillPluginOption[]>;
   getPrefillAttributes: (plugin: string) => Promise<PrefillAttributeOption[]>;
+  getFileTypes: () => Promise<
+    Array<{
+      value: string;
+      label: string;
+    }>
+  >;
+  serverUploadLimit: string;
 }
 
 const BuilderContext = React.createContext<BuilderContextType>({
@@ -46,6 +53,8 @@ const BuilderContext = React.createContext<BuilderContextType>({
   getRegistrationAttributes: async () => [],
   getPrefillPlugins: async () => [],
   getPrefillAttributes: async () => [],
+  getFileTypes: async () => [],
+  serverUploadLimit: '(unknown)',
 });
 
 BuilderContext.displayName = 'BuilderContext';

--- a/src/context.ts
+++ b/src/context.ts
@@ -23,6 +23,31 @@ interface ComponentTranslationsRef {
 }
 
 /*
+  Generic select options
+ */
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+/*
+  ZGW Document types integration
+
+  This datastructure is created by the Open Forms backend which takes the registration
+  backends on the form into account.
+ */
+export interface DocumentTypeOption {
+  backendLabel: string;
+  catalogus: {
+    domein: string;
+  };
+  informatieobjecttype: {
+    url: string;
+    omschrijving: string;
+  };
+}
+
+/*
   Builder
  */
 
@@ -35,13 +60,10 @@ export interface BuilderContextType {
   getRegistrationAttributes: (componentType: string) => Promise<RegistrationAttributeOption[]>;
   getPrefillPlugins: (componentType: string) => Promise<PrefillPluginOption[]>;
   getPrefillAttributes: (plugin: string) => Promise<PrefillAttributeOption[]>;
-  getFileTypes: () => Promise<
-    Array<{
-      value: string;
-      label: string;
-    }>
-  >;
+  getFileTypes: () => Promise<SelectOption[]>;
   serverUploadLimit: string;
+  getDocumentTypes: () => Promise<Array<DocumentTypeOption>>;
+  getConfidentialityLevels: () => Promise<SelectOption[]>;
 }
 
 const BuilderContext = React.createContext<BuilderContextType>({
@@ -55,6 +77,8 @@ const BuilderContext = React.createContext<BuilderContextType>({
   getPrefillAttributes: async () => [],
   getFileTypes: async () => [],
   serverUploadLimit: '(unknown)',
+  getDocumentTypes: async () => [],
+  getConfidentialityLevels: async () => [],
 });
 
 BuilderContext.displayName = 'BuilderContext';

--- a/src/registry/file/edit-validation.ts
+++ b/src/registry/file/edit-validation.ts
@@ -1,0 +1,7 @@
+import {IntlShape} from 'react-intl';
+
+import {buildCommonSchema} from '@/registry/validation';
+
+const schema = (intl: IntlShape) => buildCommonSchema(intl);
+
+export default schema;

--- a/src/registry/file/edit-validation.ts
+++ b/src/registry/file/edit-validation.ts
@@ -3,6 +3,27 @@ import {z} from 'zod';
 
 import {buildCommonSchema} from '@/registry/validation';
 
+const SERVER_LIMIT = '50MB';
+
+// Reference: formio's file component translateScalars method, but without the weird
+// units that don't make sense for files...
+const TRANSFORMATIONS = {
+  B: Math.pow(1024, 0),
+  KB: Math.pow(1024, 1),
+  MB: Math.pow(1024, 2),
+  GB: Math.pow(1024, 3),
+};
+
+const getSizeInBytes = (filesize: string): number | null => {
+  const match = /^(\d+)\s*(B|KB|MB|GB)?$/i.exec(filesize);
+  if (match === null) {
+    return null;
+  }
+  const size = parseInt(match[1], 10);
+  const unit = (match[2] || 'B').toUpperCase() as keyof typeof TRANSFORMATIONS;
+  return size * TRANSFORMATIONS[unit];
+};
+
 const imgSize = z.number().int().positive();
 
 const ofSchema = z.object({
@@ -19,13 +40,31 @@ const ofSchema = z.object({
     .optional(),
 });
 
-const buildFileMaxSizeSchema = (intl: IntlShape) =>
-  z.string().refine(value => /^\d+\s*(B|KB|MB|GB)/i.test(value), {
-    message: intl.formatMessage({
-      description: "File component 'fileMaxSize' validation error",
-      defaultMessage: 'Specify a positive, non-zero file size without decimals, e.g. 10MB.',
-    }),
-  });
+const buildFileMaxSizeSchema = (intl: IntlShape) => {
+  const serverLimitInBytes = getSizeInBytes(SERVER_LIMIT) ?? Number.MAX_SAFE_INTEGER;
+  return z
+    .string()
+    .transform((val, ctx) => {
+      const sizeInBytes = getSizeInBytes(val);
+      if (sizeInBytes === null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: intl.formatMessage({
+            description: "File component 'fileMaxSize' validation error",
+            defaultMessage: 'Specify a positive, non-zero file size without decimals, e.g. 10MB.',
+          }),
+        });
+        return z.NEVER;
+      }
+      return sizeInBytes;
+    })
+    .refine(value => value <= serverLimitInBytes, {
+      message: intl.formatMessage({
+        description: "File component 'fileMaxSize' greater than server limit",
+        defaultMessage: 'Specify a file size less than or equal to the server upload limit.',
+      }),
+    });
+};
 
 const buildFileSchema = (intl: IntlShape) =>
   z.object({
@@ -33,14 +72,6 @@ const buildFileSchema = (intl: IntlShape) =>
     maxNumberOfFiles: z.union([z.null(), z.number().int().positive().optional()]),
     fileMaxSize: buildFileMaxSizeSchema(intl).optional(),
   });
-
-/**
- * @todo implement validations:
- *
- * - validate fileMaxSize <= serverUploadLimit from context, if set. -> pass builder
- *   context by default to validator factory? we already pass the intl object so there's
- *   precedent...
- */
 
 const schema = (intl: IntlShape) => buildCommonSchema(intl).and(buildFileSchema(intl));
 

--- a/src/registry/file/edit-validation.ts
+++ b/src/registry/file/edit-validation.ts
@@ -1,16 +1,47 @@
 import {IntlShape} from 'react-intl';
+import {z} from 'zod';
 
 import {buildCommonSchema} from '@/registry/validation';
+
+const imgSize = z.number().int().positive();
+
+const ofSchema = z.object({
+  image: z
+    .object({
+      resize: z
+        .object({
+          apply: z.boolean().optional(),
+          width: imgSize.optional(),
+          height: imgSize.optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+const buildFileMaxSizeSchema = (intl: IntlShape) =>
+  z.string().refine(value => /^\d+\s*(B|KB|MB|GB)/i.test(value), {
+    message: intl.formatMessage({
+      description: "File component 'fileMaxSize' validation error",
+      defaultMessage: 'Specify a positive, non-zero file size without decimals, e.g. 10MB.',
+    }),
+  });
+
+const buildFileSchema = (intl: IntlShape) =>
+  z.object({
+    of: ofSchema.optional(),
+    maxNumberOfFiles: z.union([z.null(), z.number().int().positive().optional()]),
+    fileMaxSize: buildFileMaxSizeSchema(intl).optional(),
+  });
 
 /**
  * @todo implement validations:
  *
- * - fileMaxSize must be int (bytes) or int(K|M)B (?) -> check how fileMaxSize is
- *   handled in the backend, if at all.
- * - validate fileMaxSize <= serverUploadLimit from context, if set.
- * - maxNumberOfFiles must be positive integer
+ * - validate fileMaxSize <= serverUploadLimit from context, if set. -> pass builder
+ *   context by default to validator factory? we already pass the intl object so there's
+ *   precedent...
  */
 
-const schema = (intl: IntlShape) => buildCommonSchema(intl);
+const schema = (intl: IntlShape) => buildCommonSchema(intl).and(buildFileSchema(intl));
 
 export default schema;

--- a/src/registry/file/edit-validation.ts
+++ b/src/registry/file/edit-validation.ts
@@ -2,6 +2,15 @@ import {IntlShape} from 'react-intl';
 
 import {buildCommonSchema} from '@/registry/validation';
 
+/**
+ * @todo implement validations:
+ *
+ * - fileMaxSize must be int (bytes) or int(K|M)B (?) -> check how fileMaxSize is
+ *   handled in the backend, if at all.
+ * - validate fileMaxSize <= serverUploadLimit from context, if set.
+ * - maxNumberOfFiles must be positive integer
+ */
+
 const schema = (intl: IntlShape) => buildCommonSchema(intl);
 
 export default schema;

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -19,10 +19,11 @@ import {
   useDeriveComponentKey,
 } from '@/components/builder';
 import {LABELS} from '@/components/builder/messages';
-import {Checkbox, Tab, TabList, TabPanel, Tabs, TextField} from '@/components/formio';
+import {Tab, TabList, TabPanel, Tabs} from '@/components/formio';
 import {getErrorNames} from '@/utils/errors';
 
 import {EditFormDefinition} from '../types';
+import FileTabFields from './file-tab';
 
 /**
  * Form to configure a Formio 'file' type component.
@@ -65,7 +66,9 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
         />
         <BuilderTabs.Advanced hasErrors={hasAnyError('conditional')} />
         <BuilderTabs.Validation hasErrors={hasAnyError('validate')} />
-        <Tab hasErrors={hasAnyError('file')}>
+        <Tab
+          hasErrors={hasAnyError('file', 'useConfigFiletypes', 'fileMaxSize', 'maxNumberOfFiles')}
+        >
           <FormattedMessage
             description="Component edit form tab title for 'File' tab"
             defaultMessage="File"
@@ -100,7 +103,9 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
       </TabPanel>
 
       {/* File tab */}
-      <TabPanel></TabPanel>
+      <TabPanel>
+        <FileTabFields />
+      </TabPanel>
 
       {/* Registration tab */}
       <TabPanel>TODO</TabPanel>
@@ -119,9 +124,15 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
   );
 };
 
+/**
+ *
+ * @todo options.withCredentials: true seems to be set somewhere -> session cookie
+ *   needs to be sent by the SDK/client!
+ */
 EditForm.defaultValues = {
   storage: 'url',
   url: '',
+
   // basic tab
   label: '',
   key: '',
@@ -151,7 +162,8 @@ EditForm.defaultValues = {
     type: [],
     allowedTypesLabels: [],
   },
-  filePattern: '',
+  filePattern: '*',
+  useConfigFiletypes: false,
   // registration tab
   registration: {
     informatieobjecttype: '',

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -141,9 +141,8 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
 EditForm.defaultValues = {
   storage: 'url',
   url: '',
-  // TODO -> add to type definition!
-  // options: '{"withCredentials": true}',
-  // webcam: false,
+  options: {withCredentials: true},
+  webcam: false,
 
   // basic tab
   label: '',

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -67,7 +67,13 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
         <BuilderTabs.Advanced hasErrors={hasAnyError('conditional')} />
         <BuilderTabs.Validation hasErrors={hasAnyError('validate')} />
         <Tab
-          hasErrors={hasAnyError('file', 'useConfigFiletypes', 'fileMaxSize', 'maxNumberOfFiles')}
+          hasErrors={hasAnyError(
+            'file',
+            'useConfigFiletypes',
+            'of',
+            'fileMaxSize',
+            'maxNumberOfFiles'
+          )}
         >
           <FormattedMessage
             description="Component edit form tab title for 'File' tab"
@@ -132,6 +138,9 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
 EditForm.defaultValues = {
   storage: 'url',
   url: '',
+  // TODO -> add to type definition!
+  // options: '{"withCredentials": true}',
+  // webcam: false,
 
   // basic tab
   label: '',
@@ -164,6 +173,17 @@ EditForm.defaultValues = {
   },
   filePattern: '*',
   useConfigFiletypes: false,
+  of: {
+    image: {
+      resize: {
+        apply: false,
+        width: 2000,
+        height: 2000,
+      },
+    },
+  },
+  fileMaxSize: '10MB',
+  maxNumberOfFiles: null,
   // registration tab
   registration: {
     informatieobjecttype: '',

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -24,6 +24,7 @@ import {getErrorNames} from '@/utils/errors';
 
 import {EditFormDefinition} from '../types';
 import FileTabFields from './file-tab';
+import RegistrationTabFields from './registration-tab';
 
 /**
  * Form to configure a Formio 'file' type component.
@@ -114,7 +115,9 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
       </TabPanel>
 
       {/* Registration tab */}
-      <TabPanel>TODO</TabPanel>
+      <TabPanel>
+        <RegistrationTabFields />
+      </TabPanel>
 
       {/* Translations */}
       <TabPanel>

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -1,0 +1,164 @@
+import {FileComponentSchema} from '@open-formulieren/types';
+import {useFormikContext} from 'formik';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {
+  BuilderTabs,
+  ClearOnHide,
+  Description,
+  Hidden,
+  IsSensitiveData,
+  Key,
+  Label,
+  Multiple,
+  PresentationConfig,
+  SimpleConditional,
+  Tooltip,
+  Translations,
+  Validate,
+  useDeriveComponentKey,
+} from '@/components/builder';
+import {LABELS} from '@/components/builder/messages';
+import {Checkbox, Tab, TabList, TabPanel, Tabs, TextField} from '@/components/formio';
+import {getErrorNames} from '@/utils/errors';
+
+import {EditFormDefinition} from '../types';
+
+/**
+ * Form to configure a Formio 'file' type component.
+ */
+const EditForm: EditFormDefinition<FileComponentSchema> = () => {
+  const intl = useIntl();
+  const [isKeyManuallySetRef, generatedKey] = useDeriveComponentKey();
+  const {errors} = useFormikContext<FileComponentSchema>();
+
+  const erroredFields = Object.keys(errors).length
+    ? getErrorNames<FileComponentSchema>(errors)
+    : [];
+  // TODO: pattern match instead of just string inclusion?
+  // TODO: move into more generically usuable utility when we implement other component
+  // types
+  const hasAnyError = (...fieldNames: string[]): boolean => {
+    if (!erroredFields.length) return false;
+    return fieldNames.some(name => erroredFields.includes(name));
+  };
+
+  Validate.useManageValidatorsTranslations<FileComponentSchema>(['required']);
+
+  return (
+    <Tabs>
+      <TabList>
+        <BuilderTabs.Basic
+          hasErrors={hasAnyError(
+            'label',
+            'key',
+            'description',
+            'tooltip',
+            'showInSummary',
+            'showInEmail',
+            'showInPDF',
+            'multiple',
+            'hidden',
+            'clearOnHide',
+            'isSensitiveData'
+          )}
+        />
+        <BuilderTabs.Advanced hasErrors={hasAnyError('conditional')} />
+        <BuilderTabs.Validation hasErrors={hasAnyError('validate')} />
+        <Tab hasErrors={hasAnyError('file')}>
+          <FormattedMessage
+            description="Component edit form tab title for 'File' tab"
+            defaultMessage="File"
+          />
+        </Tab>
+        <BuilderTabs.Registration hasErrors={hasAnyError('registration')} />
+        <BuilderTabs.Translations hasErrors={hasAnyError('openForms.translations')} />
+      </TabList>
+
+      {/* Basic tab */}
+      <TabPanel>
+        <Label />
+        <Key isManuallySetRef={isKeyManuallySetRef} generatedValue={generatedKey} />
+        <Description />
+        <Tooltip />
+        <PresentationConfig />
+        <Multiple<FileComponentSchema> />
+        <Hidden />
+        <ClearOnHide />
+        <IsSensitiveData />
+      </TabPanel>
+
+      {/* Advanced tab */}
+      <TabPanel>
+        <SimpleConditional />
+      </TabPanel>
+
+      {/* Validation tab */}
+      <TabPanel>
+        <Validate.Required />
+        <Validate.ValidationErrorTranslations />
+      </TabPanel>
+
+      {/* File tab */}
+      <TabPanel></TabPanel>
+
+      {/* Registration tab */}
+      <TabPanel>TODO</TabPanel>
+
+      {/* Translations */}
+      <TabPanel>
+        <Translations.ComponentTranslations<FileComponentSchema>
+          propertyLabels={{
+            label: intl.formatMessage(LABELS.label),
+            description: intl.formatMessage(LABELS.description),
+            tooltip: intl.formatMessage(LABELS.tooltip),
+          }}
+        />
+      </TabPanel>
+    </Tabs>
+  );
+};
+
+EditForm.defaultValues = {
+  storage: 'url',
+  url: '',
+  // basic tab
+  label: '',
+  key: '',
+  description: '',
+  tooltip: '',
+  showInSummary: true,
+  showInEmail: false,
+  showInPDF: true,
+  multiple: false,
+  hidden: false,
+  clearOnHide: true,
+  isSensitiveData: true,
+  // Advanced tab
+  conditional: {
+    show: undefined,
+    when: '',
+    eq: '',
+  },
+  // Validation tab
+  validate: {
+    required: false,
+  },
+  translatedErrors: {},
+  // file tab
+  file: {
+    name: '',
+    type: [],
+    allowedTypesLabels: [],
+  },
+  filePattern: '',
+  // registration tab
+  registration: {
+    informatieobjecttype: '',
+    bronorganisatie: '',
+    docVertrouwelijkheidaanduiding: '',
+    titel: '',
+  },
+};
+
+export default EditForm;

--- a/src/registry/file/file-tab.stories.ts
+++ b/src/registry/file/file-tab.stories.ts
@@ -1,0 +1,87 @@
+import {expect} from '@storybook/jest';
+import {Meta, StoryObj} from '@storybook/react';
+import {fireEvent, userEvent, waitFor, within} from '@storybook/testing-library';
+
+import {BuilderContextDecorator, withFormik} from '@/sb-decorators';
+
+import FileTabFields from './file-tab';
+
+export default {
+  title: 'Builder components/File upload',
+  component: FileTabFields,
+  decorators: [withFormik, BuilderContextDecorator],
+  parameters: {
+    formik: {
+      initialValues: {
+        id: 'wekruya',
+        type: 'file',
+        key: 'file',
+        label: 'A file field',
+        storage: 'url',
+        url: '',
+        file: {
+          name: '',
+          type: [],
+          allowedTypesLabels: [],
+        },
+        filePattern: '*',
+        useConfigFiletypes: false,
+        of: {
+          image: {
+            resize: {
+              apply: false,
+              width: 2000,
+              height: 2000,
+            },
+          },
+        },
+        fileMaxSize: '10MB',
+        maxNumberOfFiles: null,
+        validate: {
+          required: false,
+        },
+      },
+    },
+    modal: {noModal: true},
+    builder: {enableContext: true},
+  },
+  args: {},
+} as Meta<typeof FileTabFields>;
+
+type Story = StoryObj<typeof FileTabFields>;
+
+export const ImageResizeOptionsShown: Story = {
+  name: 'Files tab - show image resize options',
+
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await step('No resize controls initially visible', () => {
+      expect(canvas.queryByLabelText('Resize image')).not.toBeInTheDocument();
+      expect(canvas.queryByLabelText('Maximum width')).not.toBeInTheDocument();
+      expect(canvas.queryByLabelText('Maximum height')).not.toBeInTheDocument();
+    });
+
+    await step('Select image file types displays controls', async () => {
+      canvas.getByLabelText('File types').focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await waitFor(async () => {
+        await expect(canvas.queryByText('.png')).toBeVisible();
+      });
+      await userEvent.click(canvas.getByText('.png'));
+      expect(canvas.queryByLabelText('Resize image')).toBeVisible();
+      expect(canvas.queryByLabelText('Resize image')).not.toBeChecked();
+      expect(canvas.queryByLabelText('Maximum width')).not.toBeInTheDocument();
+      expect(canvas.queryByLabelText('Maximum height')).not.toBeInTheDocument();
+    });
+
+    await step('Enabling image resizing displays dimension controls', async () => {
+      fireEvent.click(canvas.getByLabelText('Resize image'));
+
+      expect(canvas.queryByLabelText('Maximum width')).toBeVisible();
+      expect(canvas.queryByLabelText('Maximum width')).toHaveDisplayValue('2000');
+      expect(canvas.queryByLabelText('Maximum height')).toBeVisible();
+      expect(canvas.queryByLabelText('Maximum height')).toHaveDisplayValue('2000');
+    });
+  },
+};

--- a/src/registry/file/file-tab.tsx
+++ b/src/registry/file/file-tab.tsx
@@ -136,8 +136,7 @@ const FileMaxSize = () => {
   const {serverUploadLimit} = useContext(BuilderContext);
   const tooltip = intl.formatMessage({
     description: "Tooltip for 'fileMaxSize' builder field",
-    defaultMessage:
-      'When this is checked, the filetypes configured in the global settings will be used.',
+    defaultMessage: 'The maximum size of a single file to upload.',
   });
 
   return (

--- a/src/registry/file/file-tab.tsx
+++ b/src/registry/file/file-tab.tsx
@@ -1,0 +1,149 @@
+import {useContext} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+import useAsync from 'react-use/esm/useAsync';
+
+import {Checkbox, NumberField, Select, TextField} from '@/components/formio';
+import {BuilderContext} from '@/context';
+
+const FileName: React.FC<{}> = () => {
+  const intl = useIntl();
+
+  const tooltip = intl.formatMessage(
+    {
+      description: "Tooltip for 'file.name' builder field",
+      defaultMessage:
+        "Specify template for name of uploaded file(s). <code>'{{ fileName }}'</code> contains the original filename.",
+    },
+    {
+      code: chunks => <code>{chunks}</code>,
+    }
+  ) as string; // library doesn't narrow the type when using template fns :(
+
+  return (
+    <TextField
+      name="file.name"
+      label={
+        <FormattedMessage
+          description="Label for 'file.name' builder field"
+          defaultMessage="File name template"
+        />
+      }
+      tooltip={tooltip}
+      placeholder={intl.formatMessage({
+        description: "placeholder for 'file.name' builder field",
+        defaultMessage: '(optional)',
+      })}
+    />
+  );
+};
+
+const FileTypesSelect: React.FC<{}> = () => {
+  const {getFileTypes} = useContext(BuilderContext);
+
+  const {value: options, loading, error} = useAsync(async () => await getFileTypes(), []);
+
+  if (error) {
+    throw error;
+  }
+
+  return (
+    <Select
+      name="file.type"
+      label={
+        <FormattedMessage
+          description="Label for 'file.type' builder field"
+          defaultMessage="File types"
+        />
+      }
+      isLoading={loading}
+      isClearable
+      options={options}
+      valueProperty="value"
+    />
+  );
+};
+
+const UseConfigFiletypes = () => {
+  const intl = useIntl();
+  const tooltip = intl.formatMessage({
+    description: "Tooltip for 'useConfigFiletypes' builder field",
+    defaultMessage:
+      'When this is checked, the filetypes configured in the global settings will be used.',
+  });
+  return (
+    <Checkbox
+      name="useConfigFiletypes"
+      label={
+        <FormattedMessage
+          description="Label for 'useConfigFiletypes' builder field"
+          defaultMessage="Use globally configured filetypes"
+        />
+      }
+      tooltip={tooltip}
+    />
+  );
+};
+
+const FileMaxSize = () => {
+  const intl = useIntl();
+  const {serverUploadLimit} = useContext(BuilderContext);
+  const tooltip = intl.formatMessage({
+    description: "Tooltip for 'fileMaxSize' builder field",
+    defaultMessage:
+      'When this is checked, the filetypes configured in the global settings will be used.',
+  });
+
+  return (
+    <TextField
+      name="fileMaxSize"
+      label={
+        <FormattedMessage
+          description="Label for 'fileMaxSize' builder field"
+          defaultMessage="Maximum file size"
+        />
+      }
+      tooltip={tooltip}
+      description={
+        <FormattedMessage
+          description="Description for 'fileMaxSize' builder field"
+          defaultMessage="Note that the server upload limit is {serverUploadLimit}."
+          values={{serverUploadLimit}}
+        />
+      }
+    />
+  );
+};
+
+const MaxNumberOfFiles = () => {
+  const intl = useIntl();
+  const tooltip = intl.formatMessage({
+    description: "Tooltip for 'maxNumberOfFiles' builder field",
+    defaultMessage: 'The maximum number of files that can be uploaded.',
+  });
+  return (
+    <NumberField
+      name="maxNumberOfFiles"
+      label={
+        <FormattedMessage
+          description="Label for 'maxNumberOfFiles' builder field"
+          defaultMessage="Maximum number of files"
+        />
+      }
+      tooltip={tooltip}
+      min={0}
+      step={1}
+    />
+  );
+};
+
+const FileTabFields = () => (
+  <>
+    <FileName />
+    <FileTypesSelect />
+    <UseConfigFiletypes />
+    <FileMaxSize />
+    <MaxNumberOfFiles />
+  </>
+);
+
+export default FileTabFields;

--- a/src/registry/file/file-tab.tsx
+++ b/src/registry/file/file-tab.tsx
@@ -8,25 +8,6 @@ import useAsync from 'react-use/esm/useAsync';
 import {Checkbox, Component, NumberField, Select, TextField} from '@/components/formio';
 import {BuilderContext} from '@/context';
 
-// // lifted from formio's file component in 4.13.x
-// const translateScalars(str) {
-//   if (typeof str === 'string') {
-//     if (str.search(/kb/i) === str.length - 2) {
-//       return parseFloat(str.substring(0, str.length - 2) * 1024);
-//     }
-//     if (str.search(/mb/i) === str.length - 2) {
-//       return parseFloat(str.substring(0, str.length - 2) * 1024 * 1024);
-//     }
-//     if (str.search(/gb/i) === str.length - 2) {
-//       return parseFloat(str.substring(0, str.length - 2) * 1024 * 1024 * 1024);
-//     }
-//     if (str.search(/b/i) === str.length - 1) {
-//       return parseFloat(str.substring(0, str.length - 1));
-//     }
-//   }
-//   return str;
-// }
-
 const hasImageMimeType = (mimetypes: string[]): boolean =>
   mimetypes.some(mimeType => mimeType.startsWith('image/') || mimeType === '*');
 

--- a/src/registry/file/file-validation.stories.ts
+++ b/src/registry/file/file-validation.stories.ts
@@ -172,9 +172,7 @@ export const ValidateMaxFileSizeAgainstServerValue: Story = {
     await userEvent.type(fileSize, '100MB');
     await userEvent.keyboard('[Tab]');
     expect(
-      await canvas.findByText(
-        "Specify a file size that's less than or equal to the server upload limit."
-      )
+      await canvas.findByText('Specify a file size less than or equal to the server upload limit.')
     ).toBeVisible();
   },
 };

--- a/src/registry/file/file-validation.stories.ts
+++ b/src/registry/file/file-validation.stories.ts
@@ -158,3 +158,23 @@ export const ValidMaxFileSize: Story = {
     });
   },
 };
+
+export const ValidateMaxFileSizeAgainstServerValue: Story = {
+  name: 'validate fileMaxSize against serverUploadLimit',
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('link', {name: 'File'}));
+    const fileSize = canvas.getByLabelText('Maximum file size');
+
+    await userEvent.clear(fileSize);
+    await userEvent.type(fileSize, '100MB');
+    await userEvent.keyboard('[Tab]');
+    expect(
+      await canvas.findByText(
+        "Specify a file size that's less than or equal to the server upload limit."
+      )
+    ).toBeVisible();
+  },
+};

--- a/src/registry/file/file-validation.stories.ts
+++ b/src/registry/file/file-validation.stories.ts
@@ -1,0 +1,160 @@
+import {expect} from '@storybook/jest';
+import {Meta, StoryObj} from '@storybook/react';
+import {fireEvent, userEvent, within} from '@storybook/testing-library';
+
+import ComponentEditForm from '@/components/ComponentEditForm';
+import {BuilderContextDecorator} from '@/sb-decorators';
+
+export default {
+  title: 'Builder components/File upload/Validations',
+  component: ComponentEditForm,
+  decorators: [BuilderContextDecorator],
+  parameters: {
+    builder: {enableContext: true},
+  },
+  args: {
+    isNew: true,
+    component: {
+      id: 'kiweljhr',
+      storage: 'url',
+      url: '',
+      type: 'file',
+      key: 'file',
+      label: 'A file upload',
+      file: {
+        name: '',
+        type: [],
+        allowedTypesLabels: [],
+      },
+      filePattern: '',
+    },
+    builderInfo: {
+      title: 'File upload',
+      icon: '',
+      group: 'file',
+      weight: 10,
+      schema: {},
+    },
+  },
+} as Meta<typeof ComponentEditForm>;
+
+type Story = StoryObj<typeof ComponentEditForm>;
+
+export const ResizeOptions: Story = {
+  name: 'resize options',
+
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await step('Configure image file types', async () => {
+      await userEvent.click(canvas.getByRole('link', {name: 'File'}));
+      canvas.getByLabelText('File types').focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await userEvent.click(await canvas.findByText('.jpg'));
+      const enableResize = await canvas.findByLabelText('Resize image');
+      fireEvent.click(enableResize);
+    });
+
+    await step('Enter invalid dimension values', async () => {
+      const maxWidth = await canvas.findByLabelText('Maximum width');
+      await userEvent.clear(maxWidth);
+      await userEvent.type(maxWidth, '-100');
+
+      const maxHeight = await canvas.findByLabelText('Maximum height');
+      await userEvent.clear(maxHeight);
+      await userEvent.type(maxHeight, '3.14');
+
+      await userEvent.keyboard('[Tab]');
+
+      expect(await canvas.findByText('Number must be greater than 0')).toBeVisible();
+      expect(await canvas.findByText('Expected integer, received float')).toBeVisible();
+    });
+  },
+};
+
+export const MaxNumberOfFiles: Story = {
+  name: 'validate maxNumberOfFiles',
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('link', {name: 'File'}));
+    await userEvent.type(canvas.getByLabelText('Maximum number of files'), '0');
+    await userEvent.keyboard('[Tab]');
+
+    expect(await canvas.findByText('Number must be greater than 0')).toBeVisible();
+  },
+};
+
+export const MaxFileSize: Story = {
+  name: 'validate fileMaxSize',
+
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('link', {name: 'File'}));
+    const fileSize = canvas.getByLabelText('Maximum file size');
+
+    await step('Negative file size', async () => {
+      await userEvent.clear(fileSize);
+      await userEvent.type(fileSize, '-10MB');
+      await userEvent.keyboard('[Tab]');
+      expect(
+        await canvas.findByText(
+          'Specify a positive, non-zero file size without decimals, e.g. 10MB.'
+        )
+      ).toBeVisible();
+    });
+
+    await step('Decimal file size (period)', async () => {
+      await userEvent.clear(fileSize);
+      await userEvent.type(fileSize, '10.5MB');
+      await userEvent.keyboard('[Tab]');
+      expect(
+        await canvas.findByText(
+          'Specify a positive, non-zero file size without decimals, e.g. 10MB.'
+        )
+      ).toBeVisible();
+    });
+
+    await step('Decimal file size (comma)', async () => {
+      await userEvent.clear(fileSize);
+      await userEvent.type(fileSize, '10,5 MB');
+      await userEvent.keyboard('[Tab]');
+      expect(
+        await canvas.findByText(
+          'Specify a positive, non-zero file size without decimals, e.g. 10MB.'
+        )
+      ).toBeVisible();
+    });
+  },
+};
+
+export const ValidMaxFileSize: Story = {
+  name: 'valid fileMaxSize variants',
+
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('link', {name: 'File'}));
+    const fileSize = canvas.getByLabelText('Maximum file size');
+
+    await step('Whitespace between value and unit', async () => {
+      await userEvent.clear(fileSize);
+      await userEvent.type(fileSize, '15    mb');
+      await userEvent.keyboard('[Tab]');
+      expect(
+        canvas.queryByText('Specify a positive, non-zero file size without decimals, e.g. 10MB.')
+      ).not.toBeInTheDocument();
+    });
+
+    await step('Accept non-MB values', async () => {
+      await userEvent.clear(fileSize);
+      await userEvent.type(fileSize, '200 KB');
+      await userEvent.keyboard('[Tab]');
+      expect(
+        canvas.queryByText('Specify a positive, non-zero file size without decimals, e.g. 10MB.')
+      ).not.toBeInTheDocument();
+    });
+  },
+};

--- a/src/registry/file/index.ts
+++ b/src/registry/file/index.ts
@@ -1,10 +1,10 @@
-// import EditForm from './edit';
-// import validationSchema from './edit-validation';
+import EditForm from './edit';
+import validationSchema from './edit-validation';
 import Preview from './preview';
 
 export default {
-  // edit: EditForm,
-  // editSchema: validationSchema,
+  edit: EditForm,
+  editSchema: validationSchema,
   preview: Preview,
   defaultValue: [],
 };

--- a/src/registry/file/index.ts
+++ b/src/registry/file/index.ts
@@ -1,0 +1,10 @@
+// import EditForm from './edit';
+// import validationSchema from './edit-validation';
+import Preview from './preview';
+
+export default {
+  // edit: EditForm,
+  // editSchema: validationSchema,
+  preview: Preview,
+  defaultValue: [],
+};

--- a/src/registry/file/preview.tsx
+++ b/src/registry/file/preview.tsx
@@ -1,0 +1,82 @@
+import {FileComponentSchema} from '@open-formulieren/types';
+import {FormattedMessage} from 'react-intl';
+
+import {Component, Description} from '@/components/formio';
+
+import {ComponentPreviewProps} from '../types';
+
+/**
+ * Show a formio file component preview.
+ *
+ * NOTE: for the time being, this is rendered in the default Formio bootstrap style,
+ * however at some point this should use the components of
+ * @open-formulieren/formio-renderer instead for a more accurate preview.
+ */
+const Preview: React.FC<ComponentPreviewProps<FileComponentSchema>> = ({component}) => {
+  const {key, label, description, tooltip, validate = {}} = component;
+  const {required = false} = validate;
+
+  return (
+    <Component
+      type="file"
+      field={key}
+      required={required}
+      htmlId={`editform-${key}`}
+      label={label}
+      tooltip={tooltip}
+    >
+      <ul className="list-group list-group-striped">
+        <li className="list-group-item list-group-header hidden-xs hidden-sm">
+          <div className="row">
+            <div className="col-md-1"></div>
+
+            <div className="col-md-9">
+              <strong>
+                <FormattedMessage
+                  description="file component preview: file name column header"
+                  defaultMessage="File name"
+                />
+              </strong>
+            </div>
+            <div className="col-md-2">
+              <strong>
+                <FormattedMessage
+                  description="file component preview: file size column header"
+                  defaultMessage="Size"
+                />
+              </strong>
+            </div>
+          </div>
+        </li>
+      </ul>
+
+      <div className="fileSelector">
+        <i className="fa fa-cloud-upload"></i>
+        <FormattedMessage
+          description="file component: drag/select files to upload text"
+          defaultMessage="Drag or <browse>select</browse> files to upload."
+          values={{
+            browse: nodes => (
+              <a
+                href="#"
+                className="browser"
+                onClick={e => {
+                  e.preventDefault();
+                  alert('Uploading is disabled in preview mode.');
+                }}
+              >
+                {nodes}
+              </a>
+            ),
+          }}
+        />
+        <div className="loader-wrapper">
+          <div className="loader text-center" />
+        </div>
+      </div>
+      {description && <Description text={description} />}
+    </Component>
+  );
+};
+
+export default Preview;

--- a/src/registry/file/registration-tab.stories.ts
+++ b/src/registry/file/registration-tab.stories.ts
@@ -1,6 +1,6 @@
 import {expect} from '@storybook/jest';
 import {Meta, StoryObj} from '@storybook/react';
-import {fireEvent, userEvent, waitFor, within} from '@storybook/testing-library';
+import {userEvent, within} from '@storybook/testing-library';
 
 import {BuilderContextDecorator, withFormik} from '@/sb-decorators';
 
@@ -35,10 +35,45 @@ export default {
 
 type Story = StoryObj<typeof RegistrationTabFields>;
 
-export const RegistrationTab: Story = {
-  name: 'Registration tab',
+export const DocumentTypes: Story = {
+  name: 'Registration tab - document types',
 
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
+
+    const documentTypeSelect = canvas.getByLabelText('Information object type');
+    documentTypeSelect.focus();
+    await userEvent.keyboard('[ArrowDown]');
+
+    await step('Option group labels', async () => {
+      expect(await canvas.findByText('VTH', {exact: true})).toBeVisible();
+      expect(canvas.getByText('Open Zaak > VTH', {exact: true})).toBeVisible();
+      expect(canvas.getByText('Open Zaak > SOC', {exact: true})).toBeVisible();
+    });
+
+    await step('Option labels', async () => {
+      expect(canvas.queryAllByText('Vergunning')).toHaveLength(2);
+      expect(canvas.queryAllByText('Ontheffing')).toHaveLength(1);
+      expect(canvas.queryAllByText('Aanvraag')).toHaveLength(1);
+    });
+  },
+};
+
+export const ConfidentialityLevels: Story = {
+  name: 'Registration tab - confidentiality levels',
+
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    const documentTypeSelect = canvas.getByLabelText('Confidentiality level');
+    documentTypeSelect.focus();
+    await userEvent.keyboard('[ArrowDown]');
+
+    await step('Option labels', async () => {
+      expect(canvas.queryByText('Openbaar')).toBeVisible();
+      expect(canvas.queryByText('Beperkt openbaar')).toBeVisible();
+      expect(canvas.queryByText('Zaakvertrouwelijk')).toBeVisible();
+      // there are more, but the backend provides this list via the context mechanism.
+    });
   },
 };

--- a/src/registry/file/registration-tab.stories.ts
+++ b/src/registry/file/registration-tab.stories.ts
@@ -1,0 +1,44 @@
+import {expect} from '@storybook/jest';
+import {Meta, StoryObj} from '@storybook/react';
+import {fireEvent, userEvent, waitFor, within} from '@storybook/testing-library';
+
+import {BuilderContextDecorator, withFormik} from '@/sb-decorators';
+
+import RegistrationTabFields from './registration-tab';
+
+export default {
+  title: 'Builder components/File upload',
+  component: RegistrationTabFields,
+  decorators: [withFormik, BuilderContextDecorator],
+  parameters: {
+    formik: {
+      initialValues: {
+        id: 'wekruya',
+        type: 'file',
+        key: 'file',
+        label: 'A file field',
+        storage: 'url',
+        url: '',
+        registration: {
+          informatieobjecttype: '',
+          bronorganisatie: '',
+          docVertrouwelijkheidaanduiding: '',
+          titel: '',
+        },
+      },
+    },
+    modal: {noModal: true},
+    builder: {enableContext: true},
+  },
+  args: {},
+} as Meta<typeof RegistrationTabFields>;
+
+type Story = StoryObj<typeof RegistrationTabFields>;
+
+export const RegistrationTab: Story = {
+  name: 'Registration tab',
+
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+  },
+};

--- a/src/registry/file/registration-tab.tsx
+++ b/src/registry/file/registration-tab.tsx
@@ -1,0 +1,169 @@
+import {useContext} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+import useAsync from 'react-use/esm/useAsync';
+
+import {Select, TextField} from '@/components/formio';
+import {BuilderContext, DocumentTypeOption, SelectOption} from '@/context';
+
+interface DocumentTypeOptionsGroup {
+  label: string;
+  options: Array<{
+    value: string;
+    label: string;
+  }>;
+}
+
+const groupDocumentTypeOptions = (options: DocumentTypeOption[]): DocumentTypeOptionsGroup[] => {
+  const optionsWithGroupLabel = options.map(item => {
+    const groupLabel = [item.backendLabel, item.catalogus.domein].filter(Boolean).join(' > ');
+    return {
+      groupLabel,
+      value: item.informatieobjecttype.url,
+      label: item.informatieobjecttype.omschrijving,
+    };
+  });
+
+  type OptGroupsMapping = Record<string, SelectOption[]>;
+  const groups: OptGroupsMapping = optionsWithGroupLabel.reduce(
+    (accumulator: OptGroupsMapping, optionWithGroupLabel) => {
+      const {groupLabel, value, label} = optionWithGroupLabel;
+      if (!accumulator[groupLabel]) {
+        accumulator[groupLabel] = [];
+      }
+      accumulator[groupLabel].push({value, label});
+      return accumulator;
+    },
+    {}
+  );
+
+  // now convert this mapping back to a list of opt groups
+  const optGroups = Object.entries(groups).map(([groupLabel, options]) => ({
+    label: groupLabel,
+    options,
+  }));
+  return optGroups;
+};
+
+const DocumentTypeSelect: React.FC<{}> = () => {
+  const intl = useIntl();
+  const {getDocumentTypes} = useContext(BuilderContext);
+  const {value: options, loading, error} = useAsync(async () => await getDocumentTypes(), []);
+  if (error) {
+    throw error;
+  }
+
+  const tooltip = intl.formatMessage({
+    description: "Tooltip for 'registration.informatieobjecttype' builder field",
+    defaultMessage: `Save the attachment in the Documents API with this InformatieObjectType. If
+    unspecified, the registration plugin defaults are used.`,
+  });
+
+  return (
+    <Select
+      name="registration.informatieobjecttype"
+      label={
+        <FormattedMessage
+          description="Label for 'registration.informatieobjecttype' builder field"
+          defaultMessage="Information object type"
+        />
+      }
+      tooltip={tooltip}
+      isLoading={loading}
+      isClearable
+      isMulti
+      options={groupDocumentTypeOptions(options || [])}
+    />
+  );
+};
+
+const SourceOrganisation = () => {
+  const intl = useIntl();
+  const tooltip = intl.formatMessage({
+    description: "Tooltip for 'registration.bronorganisatie' builder field",
+    defaultMessage: 'RSIN of the organization which creates the ENKELVOUDIGINFORMATIEOBJECT.',
+  });
+
+  return (
+    <TextField
+      name="registration.bronorganisatie"
+      label={
+        <FormattedMessage
+          description="Label for 'registration.bronorganisatie' builder field"
+          defaultMessage="Bronorganisatie"
+        />
+      }
+      tooltip={tooltip}
+    />
+  );
+};
+
+const ConfidentialityLevelSelect: React.FC<{}> = () => {
+  const intl = useIntl();
+  const {getConfidentialityLevels} = useContext(BuilderContext);
+  const {
+    value: options,
+    loading,
+    error,
+  } = useAsync(async () => await getConfidentialityLevels(), []);
+  if (error) {
+    throw error;
+  }
+
+  const tooltip = intl.formatMessage({
+    description: "Tooltip for 'registration.docVertrouwelijkheidaanduiding' builder field",
+    defaultMessage:
+      'Indication of the level to which extent the INFORMATIEOBJECT is meant to be public.',
+  });
+
+  return (
+    <Select
+      name="registration.docVertrouwelijkheidaanduiding"
+      label={
+        <FormattedMessage
+          description="Label for 'registration.docVertrouwelijkheidaanduiding' builder field"
+          defaultMessage="Confidentiality level"
+        />
+      }
+      tooltip={tooltip}
+      isLoading={loading}
+      isClearable
+      isMulti
+      options={options}
+      valueProperty="url"
+    />
+  );
+};
+
+const Title = () => {
+  const intl = useIntl();
+  const tooltip = intl.formatMessage({
+    description: "Tooltip for 'registration.titel' builder field",
+    defaultMessage: 'The name under which the INFORMATIEOBJECT is formally known.',
+  });
+
+  return (
+    <TextField
+      name="registration.titel"
+      label={
+        <FormattedMessage
+          description="Label for 'registration.titel' builder field"
+          defaultMessage="Title"
+        />
+      }
+      tooltip={tooltip}
+    />
+  );
+};
+
+const RegistrationTabFields: React.FC<{}> = () => {
+  return (
+    <>
+      <DocumentTypeSelect />
+      <SourceOrganisation />
+      <ConfidentialityLevelSelect />
+      <Title />
+    </>
+  );
+};
+
+export default RegistrationTabFields;

--- a/src/registry/file/registration-tab.tsx
+++ b/src/registry/file/registration-tab.tsx
@@ -92,6 +92,7 @@ const SourceOrganisation = () => {
         />
       }
       tooltip={tooltip}
+      inputMode="numeric"
     />
   );
 };

--- a/src/registry/file/registration-tab.tsx
+++ b/src/registry/file/registration-tab.tsx
@@ -70,7 +70,6 @@ const DocumentTypeSelect: React.FC<{}> = () => {
       tooltip={tooltip}
       isLoading={loading}
       isClearable
-      isMulti
       options={groupDocumentTypeOptions(options || [])}
     />
   );
@@ -127,9 +126,8 @@ const ConfidentialityLevelSelect: React.FC<{}> = () => {
       tooltip={tooltip}
       isLoading={loading}
       isClearable
-      isMulti
       options={options}
-      valueProperty="url"
+      valueProperty="value"
     />
   );
 };

--- a/src/registry/index.tsx
+++ b/src/registry/index.tsx
@@ -4,6 +4,7 @@ import DateField from './date';
 import DateTimeField from './datetime';
 import Email from './email';
 import Fallback from './fallback';
+import FileUpload from './file';
 import NumberField from './number';
 import PhoneNumber from './phonenumber';
 import Postcode from './postcode';
@@ -34,6 +35,7 @@ const REGISTRY: Registry = {
   time: TimeField,
   phoneNumber: PhoneNumber,
   postcode: Postcode,
+  file: FileUpload,
 };
 
 export {Fallback};

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,6 +1,7 @@
 import {IntlShape} from 'react-intl';
 import {z} from 'zod';
 
+import {BuilderContextType} from '@/context';
 import {AnyComponentSchema, FallbackSchema} from '@/types';
 
 // Edit form
@@ -26,7 +27,7 @@ export type Preview<S extends AnyComponentSchema | FallbackSchema> = React.FC<
 
 export interface RegistryEntry<S extends AnyComponentSchema | FallbackSchema> {
   edit: EditFormDefinition<S>;
-  editSchema: (intl: IntlShape) => z.ZodFirstPartySchemaTypes;
+  editSchema: (intl: IntlShape, builderContext: BuilderContextType) => z.ZodFirstPartySchemaTypes;
   preview: Preview<S>;
   // textfield -> string, numberfield -> number etc. This is used for the formik
   // initial data


### PR DESCRIPTION
Partly fixes open-formulieren/open-forms#2958

Implement the file component in the new form builder, which scopes the translations to the component itself and should resolve these translation issues.

- [x] Run makemessages and ship translations