### PR TITLE
:arrow_up: Upgrade to types v0.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@formatjs/cli": "^6.1.1",
         "@formatjs/ts-transformer": "^3.12.0",
         "@fortawesome/fontawesome-free": "^6.4.0",
-        "@open-formulieren/types": "^0.17.0",
+        "@open-formulieren/types": "^0.18.1",
         "@storybook/addon-actions": "^7.6.3",
         "@storybook/addon-essentials": "^7.6.3",
         "@storybook/addon-interactions": "^7.6.3",
@@ -4493,9 +4493,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.17.0.tgz",
-      "integrity": "sha512-pxi7rhyzLfHDlekW3RucktCP79qh9q90bi/pDOCMYroiih9L6svUr2X4A7aiavcQe8yfB8MzzA+Ig3zDSf4LDA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.18.1.tgz",
+      "integrity": "sha512-ecMrF8xEnbCRfza7kThVNWviTIoqaCc/pQJ5CJdeFUWt9XA8NQsP2qOC7JxO6rO+gJYWytGV+0PSMurGKjK1vQ==",
       "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
@@ -26309,9 +26309,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.17.0.tgz",
-      "integrity": "sha512-pxi7rhyzLfHDlekW3RucktCP79qh9q90bi/pDOCMYroiih9L6svUr2X4A7aiavcQe8yfB8MzzA+Ig3zDSf4LDA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.18.1.tgz",
+      "integrity": "sha512-ecMrF8xEnbCRfza7kThVNWviTIoqaCc/pQJ5CJdeFUWt9XA8NQsP2qOC7JxO6rO+gJYWytGV+0PSMurGKjK1vQ==",
       "dev": true
     },
     "@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@formatjs/cli": "^6.1.1",
     "@formatjs/ts-transformer": "^3.12.0",
     "@fortawesome/fontawesome-free": "^6.4.0",
-    "@open-formulieren/types": "^0.17.0",
+    "@open-formulieren/types": "^0.18.1",
     "@storybook/addon-actions": "^7.6.3",
     "@storybook/addon-essentials": "^7.6.3",
     "@storybook/addon-interactions": "^7.6.3",


### PR DESCRIPTION
Doing this as a separate PR so that we can (hopefully) get it merged so everyone can continue working on features that depend on it in parallel.