### PR TITLE
Delete dead translations code

### DIFF
--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -22,13 +22,6 @@ import {ValidatorOption} from './builder/validate/validator-select';
 export default {
   title: 'Public API/ComponentConfiguration',
   component: ComponentConfiguration,
-  argTypes: {
-    componentTranslationsRef: {
-      table: {
-        disable: true,
-      },
-    },
-  },
   args: {
     isNew: true,
     otherComponents: [{type: 'select', label: 'A select', key: 'aSelect'}],
@@ -58,12 +51,6 @@ export default {
     },
     supportedLanguageCodes: ['nl'],
     fileTypes: DEFAULT_FILE_TYPES,
-    translationsStore: {
-      nl: {
-        'A select': 'Een dropdown',
-        'A text field': 'Een tekstveld',
-      },
-    },
     builderInfo: {
       title: 'Text field',
       group: 'basic',
@@ -77,11 +64,6 @@ export default {
 interface TemplateArgs {
   component: AnyComponentSchema;
   supportedLanguageCodes: SupportedLocales[];
-  translationsStore: {
-    [key: string]: {
-      [key: string]: string;
-    };
-  };
   otherComponents: AnyComponentSchema[];
   validatorPlugins: ValidatorOption[];
   registrationAttributes: RegistrationAttributeOption[];
@@ -103,7 +85,6 @@ const Template: StoryFn<TemplateArgs> = ({
   prefillPlugins,
   prefillAttributes,
   supportedLanguageCodes,
-  translationsStore,
   fileTypes,
   isNew,
   builderInfo,
@@ -115,7 +96,6 @@ const Template: StoryFn<TemplateArgs> = ({
     uniquifyKey={(key: string) => key}
     supportedLanguageCodes={supportedLanguageCodes}
     richTextColors={DEFAULT_COLORS}
-    componentTranslationsRef={{current: translationsStore}}
     getFormComponents={() => otherComponents}
     getValidatorPlugins={async () => validatorPlugins}
     getRegistrationAttributes={async () => registrationAttributes}

--- a/src/components/ComponentConfiguration.tsx
+++ b/src/components/ComponentConfiguration.tsx
@@ -13,7 +13,6 @@ export interface ComponentConfigurationProps extends BuilderContextType, Compone
  *
  * @param options.uniquifyKey              Function to make component key unique in the context of all existing components.
  * @param options.getFormComponents        Function returning all other Formio components in the builder context.
- * @param options.componentTranslationsRef Object containing the existing translations from other components, keyed by language code. Each entry is a map of literal => translation.
  * @param options.isNew                    Whether the Formio component is a new component being added or an existing being edited.
  * @param options.component                The (starter) schema of the Formio component being edited.
  * @param options.builderInfo              Meta information from the builder configuration for the Formio component.
@@ -26,7 +25,6 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
   uniquifyKey,
   supportedLanguageCodes = ['nl', 'en'],
   richTextColors,
-  componentTranslationsRef,
   getFormComponents,
   getValidatorPlugins,
   getRegistrationAttributes,
@@ -49,7 +47,6 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
       uniquifyKey,
       supportedLanguageCodes,
       richTextColors,
-      componentTranslationsRef,
       getFormComponents,
       getValidatorPlugins,
       getRegistrationAttributes,

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,22 +9,6 @@ import {AuthPluginOption} from '@/registry/cosignV1/edit';
 import {AnyComponentSchema} from '@/types';
 
 /*
-  Translations
- */
-
-interface TranslationsMap {
-  [key: string]: string;
-}
-
-interface TranslationsStore {
-  [key: string]: TranslationsMap;
-}
-
-export interface ComponentTranslationsRef {
-  current: null | TranslationsStore;
-}
-
-/*
   Generic select options
  */
 export interface SelectOption {
@@ -57,7 +41,6 @@ export interface BuilderContextType {
   uniquifyKey: (key: string) => string;
   supportedLanguageCodes: SupportedLocales[];
   richTextColors: ColorOption[];
-  componentTranslationsRef: ComponentTranslationsRef;
   getFormComponents: () => AnyComponentSchema[];
   getValidatorPlugins: (componentType: string) => Promise<ValidatorOption[]>;
   getRegistrationAttributes: (componentType: string) => Promise<RegistrationAttributeOption[]>;
@@ -74,7 +57,6 @@ const BuilderContext = React.createContext<BuilderContextType>({
   uniquifyKey: (key: string) => key,
   supportedLanguageCodes: ['nl', 'en'],
   richTextColors: [],
-  componentTranslationsRef: {current: null},
   getFormComponents: () => [],
   getValidatorPlugins: async () => [],
   getRegistrationAttributes: async () => [],

--- a/src/tests/test-utils.tsx
+++ b/src/tests/test-utils.tsx
@@ -8,7 +8,7 @@ import {IntlProvider} from 'react-intl';
 import {createIntl, createIntlCache} from 'react-intl';
 
 import {BuilderContext} from '@/context';
-import type {ComponentTranslationsRef, DocumentTypeOption, SelectOption} from '@/context';
+import type {DocumentTypeOption, SelectOption} from '@/context';
 import {
   CONFIDENTIALITY_LEVELS,
   DEFAULT_AUTH_PLUGINS,
@@ -30,7 +30,6 @@ import {ValidatorOption} from '../components/builder/validate/validator-select';
 
 interface BuilderOptions {
   supportedLanguageCodes: SupportedLocales[];
-  componentTranslationsRef: ComponentTranslationsRef;
   componentTree: AnyComponentSchema[];
   validatorPlugins: ValidatorOption[];
   registrationAttributes: RegistrationAttributeOption[];
@@ -69,7 +68,6 @@ const contextRender = (
               uniquifyKey: key => key,
               supportedLanguageCodes: builderOptions.supportedLanguageCodes || ['nl', 'en'],
               richTextColors: DEFAULT_COLORS,
-              componentTranslationsRef: builderOptions.componentTranslationsRef || {current: null},
               getFormComponents: () => builderOptions.componentTree || DEFAULT_COMPONENT_TREE,
               getValidatorPlugins: async () => {
                 await sleep(builderOptions.registrationAttributesDelay || 0);


### PR DESCRIPTION
There no longer is a store outside of the control of a component, instead, all translations are now stored on the component itself.