### PR TITLE
Fix multiple option breaking form preview

### DIFF
--- a/src/components/builder/multiple.tsx
+++ b/src/components/builder/multiple.tsx
@@ -10,7 +10,17 @@ const hasDefaultValue = (component: any): component is AnyComponentSchema & {def
   return hasOwnProperty(component, 'defaultValue');
 };
 
-function Multiple<T = unknown>() {
+export interface MultipleProps {
+  /**
+   * If true, toggling the 'multiple' value will toggle the default value accordingly.
+   *
+   * E.g. `defaultValue: 'aaa'` becomes `defaultValue: ['aaa']` when multiple switches
+   * from `false` to `true`.
+   */
+  updateDefaultValue?: boolean;
+}
+
+function Multiple<T = unknown>({updateDefaultValue = true}: MultipleProps) {
   const intl = useIntl();
   const {values, getFieldProps, setFieldValue} = useFormikContext<T>();
   const {onChange: formikOnChange} = getFieldProps<boolean>('multiple');
@@ -22,6 +32,10 @@ function Multiple<T = unknown>() {
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     formikOnChange(e);
+
+    // only touch default value if we're allowed to
+    if (!updateDefaultValue) return;
+
     // update the default value, if there is any
     if (!hasDefaultValue(values)) return;
     const {defaultValue} = values;

--- a/src/registry/file/edit.stories.ts
+++ b/src/registry/file/edit.stories.ts
@@ -1,0 +1,68 @@
+import {expect} from '@storybook/jest';
+import {Meta, StoryObj} from '@storybook/react';
+import {fireEvent, userEvent, within} from '@storybook/testing-library';
+
+import ComponentEditForm from '@/components/ComponentEditForm';
+import {BuilderContextDecorator} from '@/sb-decorators';
+
+export default {
+  title: 'Builder components/File upload',
+  component: ComponentEditForm,
+  decorators: [BuilderContextDecorator],
+  parameters: {
+    builder: {enableContext: true},
+  },
+  args: {
+    isNew: true,
+
+    component: {
+      id: 'kiweljhr',
+      storage: 'url',
+      webcam: false,
+      options: {
+        withCredentials: true,
+      },
+      url: '',
+      type: 'file',
+      key: 'file',
+      label: 'A file upload',
+      file: {
+        name: '',
+        type: [],
+        allowedTypesLabels: [],
+      },
+      filePattern: '',
+      defaultValue: null,
+    },
+
+    builderInfo: {
+      title: 'File upload',
+      icon: '',
+      group: 'file',
+      weight: 10,
+      schema: {},
+    },
+  },
+} satisfies Meta<typeof ComponentEditForm>;
+
+type Story = StoryObj<typeof ComponentEditForm>;
+
+export const ToggleToMultiple: Story = {
+  play: async ({canvasElement, args}) => {
+    const canvas = within(canvasElement);
+
+    // check that toggling the 'multiple' checkbox properly updates the preview and default
+    // value field. We use fireEvent because firefox borks on userEvent.click, see:
+    // https://github.com/testing-library/user-event/issues/1149
+    const multipleCheckbox = canvas.getByLabelText<HTMLInputElement>('Multiple values');
+    fireEvent.click(multipleCheckbox);
+    await expect(multipleCheckbox).toBeChecked();
+
+    // Save and check that the default value was untouched
+    await userEvent.click(canvas.getByRole('button', {name: 'Save'}));
+    expect(args.onSubmit).toHaveBeenCalled();
+    // @ts-ignore
+    const {defaultValue} = args.onSubmit.mock.calls[0][0];
+    expect(defaultValue).toBeNull();
+  },
+};

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -81,7 +81,7 @@ const EditForm: EditFormDefinition<FileComponentSchema> = () => {
         <Description />
         <Tooltip />
         <PresentationConfig />
-        <Multiple<FileComponentSchema> />
+        <Multiple<FileComponentSchema> updateDefaultValue={false} />
         <Hidden />
         <ClearOnHide />
         <IsSensitiveData />


### PR DESCRIPTION
Discovered while investigating open-formulieren/open-forms#3858

`defaultValue: [null]` crashes the preview (rightfully so).

The backend/Formio adds the `defaultValue: null`, so when toggling multiple, this turns it into `[null]`. Setting it to `defaultValue: []` (always) results in `[[]]` which is also wrong.

The `Multiple` component should not be aware of special behaviour for particular component types, so instead we allow the component edit form to control whether it can touch the `defaultValue` or not.