### PR TITLE
Include pointeers to templates documentation in the builder

### DIFF
--- a/src/components/builder/description.tsx
+++ b/src/components/builder/description.tsx
@@ -1,5 +1,7 @@
 import {FormattedMessage} from 'react-intl';
 
+import {TemplatingHint} from '@/components/builder';
+
 import {TextField} from '../formio';
 import {LABELS} from './messages';
 
@@ -8,7 +10,11 @@ import {LABELS} from './messages';
  * clarify what's expected by the end-user filling out the form.
  */
 const Description: React.FC = () => (
-  <TextField name="description" label={<FormattedMessage {...LABELS.description} />} />
+  <TextField
+    name="description"
+    label={<FormattedMessage {...LABELS.description} />}
+    tooltip={<TemplatingHint />}
+  />
 );
 
 export default Description;

--- a/src/components/builder/index.ts
+++ b/src/components/builder/index.ts
@@ -20,6 +20,7 @@ export {default as PresentationConfig} from './presentation-config';
 export {default as ComponentSelect} from './component-select';
 export {default as SimpleConditional} from './simple-conditional';
 export {default as Suffix} from './suffix';
+export {default as TemplatingHint} from './templating-hint';
 export * as Validate from './validate';
 export * as Registration from './registration';
 export * as Prefill from './prefill';

--- a/src/components/builder/label.tsx
+++ b/src/components/builder/label.tsx
@@ -1,5 +1,7 @@
 import {FormattedMessage} from 'react-intl';
 
+import {TemplatingHint} from '@/components/builder';
+
 import {TextField} from '../formio';
 import {LABELS} from './messages';
 
@@ -11,7 +13,12 @@ import {LABELS} from './messages';
  * and can typically be translated by the form designers.
  */
 const Label: React.FC = () => (
-  <TextField name="label" label={<FormattedMessage {...LABELS.label} />} required />
+  <TextField
+    name="label"
+    label={<FormattedMessage {...LABELS.label} />}
+    tooltip={<TemplatingHint />}
+    required
+  />
 );
 
 export default Label;

--- a/src/components/builder/templating-hint.tsx
+++ b/src/components/builder/templating-hint.tsx
@@ -1,0 +1,16 @@
+import {FormattedMessage} from 'react-intl';
+
+const DOCUMENTATION_LINK =
+  'https://open-forms.readthedocs.io/en/stable/manual/templates.html#hoe-het-werkt';
+
+const TemplatingHint: React.FC = () => (
+  <FormattedMessage
+    description="Description pointing to template documentation/capabilities"
+    defaultMessage="This field supports templating. See the <link>manual</link> for documentation and examples."
+    values={{
+      link: chunks => <a href={DOCUMENTATION_LINK}>{chunks}</a>,
+    }}
+  />
+);
+
+export default TemplatingHint;

--- a/src/components/builder/tooltip.tsx
+++ b/src/components/builder/tooltip.tsx
@@ -1,5 +1,7 @@
 import {FormattedMessage} from 'react-intl';
 
+import {TemplatingHint} from '@/components/builder';
+
 import {TextField} from '../formio';
 import {LABELS} from './messages';
 
@@ -8,7 +10,11 @@ import {LABELS} from './messages';
  * clarify what's expected by the end-user filling out the form.
  */
 const Tooltip: React.FC = () => (
-  <TextField name="tooltip" label={<FormattedMessage {...LABELS.tooltip} />} />
+  <TextField
+    name="tooltip"
+    label={<FormattedMessage {...LABELS.tooltip} />}
+    tooltip={<TemplatingHint />}
+  />
 );
 
 export default Tooltip;

--- a/src/components/formio/component-label.tsx
+++ b/src/components/formio/component-label.tsx
@@ -6,7 +6,7 @@ import Tooltip from './tooltip';
 export interface ComponentLabelProps {
   required?: boolean;
   label?: React.ReactNode;
-  tooltip?: string;
+  tooltip?: React.ReactNode;
   htmlId?: string;
 }
 

--- a/src/components/formio/component.tsx
+++ b/src/components/formio/component.tsx
@@ -14,7 +14,7 @@ export interface ComponentProps {
   field?: string;
   required?: boolean;
   label?: React.ReactNode;
-  tooltip?: string;
+  tooltip?: React.ReactNode;
   htmlId?: string;
   children: React.ReactNode;
   className?: string;

--- a/src/components/formio/textfield.tsx
+++ b/src/components/formio/textfield.tsx
@@ -15,7 +15,7 @@ export interface TextFieldProps {
   name: string;
   label?: React.ReactNode;
   required?: boolean;
-  tooltip?: string;
+  tooltip?: React.ReactNode;
   description?: React.ReactNode;
   showCharCount?: boolean;
   inputMask?: string;

--- a/src/registry/content/rich-text.tsx
+++ b/src/registry/content/rich-text.tsx
@@ -12,7 +12,8 @@ import ClassicEditor from '@open-formulieren/ckeditor5-build-classic';
 import {useField} from 'formik';
 import {useContext} from 'react';
 
-import {Component} from '@/components/formio';
+import {TemplatingHint} from '@/components/builder';
+import {Component, Description} from '@/components/formio';
 import {BuilderContext} from '@/context';
 
 export type ColorOption = Required<
@@ -77,6 +78,7 @@ const RichText: React.FC<RichTextProps> = ({name, required}) => {
           helpers.setTouched(true);
         }}
       />
+      <Description text={<TemplatingHint />} />
     </Component>
   );
 };


### PR DESCRIPTION
Not all fields are covered yet, but placeholder only supports this for *some* components.

At least the label, tooltip, description and content HTML fields now inform the form designer that they can use Django template syntax.