### PR TITLE
:bug: Add missing error message codes for selectboxes

### DIFF
--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -1096,7 +1096,11 @@ export const SelectBoxes: Story = {
           plugins: [],
         },
         translatedErrors: {
-          nl: {required: ''},
+          nl: {
+            required: '',
+            minSelectedCount: '',
+            maxSelectedCount: '',
+          },
         },
         // registration tab
         registration: {
@@ -1163,7 +1167,11 @@ export const SelectBoxes: Story = {
           plugins: [],
         },
         translatedErrors: {
-          nl: {required: ''},
+          nl: {
+            required: '',
+            minSelectedCount: '',
+            maxSelectedCount: '',
+          },
         },
         // registration tab
         registration: {

--- a/src/registry/selectboxes/edit.tsx
+++ b/src/registry/selectboxes/edit.tsx
@@ -43,7 +43,11 @@ const EditForm: EditFormDefinition<SelectboxesComponentSchema> = () => {
     defaultValue,
   } = values;
 
-  Validate.useManageValidatorsTranslations<SelectboxesComponentSchema>(['required']);
+  Validate.useManageValidatorsTranslations<SelectboxesComponentSchema>([
+    'required',
+    'minSelectedCount',
+    'maxSelectedCount',
+  ]);
 
   const isManualOptions = checkIsManualOptions(values);
   const options = isManualOptions ? values.values || [] : [];


### PR DESCRIPTION
Only 'required' could have a custom error message, while we recently added 'minSelectedCount' and 'maxSelectedCount' too.

Stumbled upon it via open-formulieren/open-forms#72