### PR TITLE
:bug: Fix regression in validation error tab markings

### DIFF
--- a/src/registry/date/edit.tsx
+++ b/src/registry/date/edit.tsx
@@ -64,7 +64,13 @@ const EditForm: EditFormDefinition<DateComponentSchema> = () => {
         />
         <BuilderTabs.Advanced hasErrors={hasAnyError('conditional')} />
         <BuilderTabs.Validation
-          hasErrors={hasAnyError('validate', 'datePicker.minDate', 'datePicker.maxDate')}
+          hasErrors={hasAnyError(
+            'validate',
+            'openForms.minDate',
+            'openForms.maxDate',
+            'datePicker.minDate',
+            'datePicker.maxDate'
+          )}
         />
         <BuilderTabs.Registration hasErrors={hasAnyError('registration')} />
         <BuilderTabs.Prefill hasErrors={hasAnyError('prefill')} />

--- a/src/registry/datetime/edit.tsx
+++ b/src/registry/datetime/edit.tsx
@@ -66,7 +66,13 @@ const EditForm: EditFormDefinition<DateTimeComponentSchema> = () => {
         />
         <BuilderTabs.Advanced hasErrors={hasAnyError('conditional')} />
         <BuilderTabs.Validation
-          hasErrors={hasAnyError('validate', 'datePicker.minDate', 'datePicker.maxDate')}
+          hasErrors={hasAnyError(
+            'validate',
+            'openForms.minDate',
+            'openForms.maxDate',
+            'datePicker.minDate',
+            'datePicker.maxDate'
+          )}
         />
         <BuilderTabs.Registration hasErrors={hasAnyError('registration')} />
         <BuilderTabs.Prefill hasErrors={hasAnyError('prefill')} />


### PR DESCRIPTION
489887af9b9fc48044efc0fe4b04e097ace53046 removed the marker for validation errors because of dynamic min/max date validation behaviour.

I'll set up visual regression testing with chromatic for this because we keep ping-ponging back and forth.