### PR TITLE
Remove support for defaultValue translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@formatjs/cli": "^6.1.1",
         "@formatjs/ts-transformer": "^3.12.0",
         "@fortawesome/fontawesome-free": "^6.4.0",
-        "@open-formulieren/types": "^0.24.0",
+        "@open-formulieren/types": "^0.25.0",
         "@storybook/addon-actions": "^8.0.8",
         "@storybook/addon-essentials": "^8.0.8",
         "@storybook/addon-interactions": "^8.0.8",
@@ -5280,9 +5280,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.24.0.tgz",
-      "integrity": "sha512-sdaI+BE1g6TceU2jjOopBe/vFfRe3w3eY+TLHceUi0j9mkKX/5MppM2d0JqsesgEIv9XjBJlectxxvtbRvrCjA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.25.1.tgz",
+      "integrity": "sha512-Cm0XhsExgTqNf9wnZvtmooD+AQs2JreJH+Ajk83PogZb6pTPpnbwdH1+Jrxc8x4xagj4Nr9DbjZFi4YHJ6VcgQ==",
       "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
@@ -29634,9 +29634,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.24.0.tgz",
-      "integrity": "sha512-sdaI+BE1g6TceU2jjOopBe/vFfRe3w3eY+TLHceUi0j9mkKX/5MppM2d0JqsesgEIv9XjBJlectxxvtbRvrCjA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.25.1.tgz",
+      "integrity": "sha512-Cm0XhsExgTqNf9wnZvtmooD+AQs2JreJH+Ajk83PogZb6pTPpnbwdH1+Jrxc8x4xagj4Nr9DbjZFi4YHJ6VcgQ==",
       "dev": true
     },
     "@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@formatjs/cli": "^6.1.1",
     "@formatjs/ts-transformer": "^3.12.0",
     "@fortawesome/fontawesome-free": "^6.4.0",
-    "@open-formulieren/types": "^0.24.0",
+    "@open-formulieren/types": "^0.25.0",
     "@storybook/addon-actions": "^8.0.8",
     "@storybook/addon-essentials": "^8.0.8",
     "@storybook/addon-interactions": "^8.0.8",

--- a/src/registry/textarea/edit.tsx
+++ b/src/registry/textarea/edit.tsx
@@ -113,7 +113,6 @@ const EditForm: EditFormDefinition<TextareaComponentSchema> = () => {
             label: intl.formatMessage(LABELS.label),
             description: intl.formatMessage(LABELS.description),
             tooltip: intl.formatMessage(LABELS.tooltip),
-            defaultValue: intl.formatMessage(LABELS.defaultValue),
             placeholder: intl.formatMessage(LABELS.placeholder),
           }}
         />

--- a/src/registry/textfield/edit.tsx
+++ b/src/registry/textfield/edit.tsx
@@ -145,7 +145,6 @@ const EditForm: EditFormDefinition<TextFieldComponentSchema> = () => {
             label: intl.formatMessage(LABELS.label),
             description: intl.formatMessage(LABELS.description),
             tooltip: intl.formatMessage(LABELS.tooltip),
-            defaultValue: intl.formatMessage(LABELS.defaultValue),
             placeholder: intl.formatMessage(LABELS.placeholder),
           }}
         />


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#4362
Depends on https://github.com/open-formulieren/types/pull/49

It is unused and too complex with 'multiple: true' cases, causing crashes in the admin interface.