### PR TITLE
Deprecate textfield location derivation

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -674,6 +674,11 @@
     "description": "Component edit form tab title for 'File' tab",
     "originalDefault": "File"
   },
+  "V2/ceD": {
+    "defaultMessage": "Configuration (deprecated)",
+    "description": "Legacy text field location configuration",
+    "originalDefault": "Configuration (deprecated)"
+  },
   "V6ClU9": {
     "defaultMessage": "If the postcode and house number are entered this field will autofill with the city",
     "description": "Tooltip for 'deriveCity' builder field",
@@ -948,6 +953,11 @@
     "defaultMessage": "Email-address in this field will receive the confirmation email.",
     "description": "Tooltip for 'confirmationRecipient' builder field",
     "originalDefault": "Email-address in this field will receive the confirmation email."
+  },
+  "fGTdJz": {
+    "defaultMessage": "Deriving the location via text fields is deprecated. Use the AddressNL component instead.",
+    "description": "Location tab deprecation message",
+    "originalDefault": "Deriving the location via text fields is deprecated. Use the AddressNL component instead."
   },
   "fRMCJI": {
     "defaultMessage": "Prefill",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -684,6 +684,11 @@
     "description": "Component edit form tab title for 'File' tab",
     "originalDefault": "File"
   },
+  "V2/ceD": {
+    "defaultMessage": "Instellingen (verouderd)",
+    "description": "Legacy text field location configuration",
+    "originalDefault": "Configuration (deprecated)"
+  },
   "V6ClU9": {
     "defaultMessage": "Indien de postcode en huisnummer ingevuld zijn, dan wordt automatisch de stad ingevuld.",
     "description": "Tooltip for 'deriveCity' builder field",
@@ -960,6 +965,11 @@
     "defaultMessage": "Het e-mailadres in dit veld ontvangt de bevestigingsmail.",
     "description": "Tooltip for 'confirmationRecipient' builder field",
     "originalDefault": "Email-address in this field will receive the confirmation email."
+  },
+  "fGTdJz": {
+    "defaultMessage": "Het afleiden van adres via tekstveld-componenten is verouderd. Gebruik in de plaats de 'AddressNL'-component (in de 'Speciale velden' groep).",
+    "description": "Location tab deprecation message",
+    "originalDefault": "Deriving the location via text fields is deprecated. Use the AddressNL component instead."
   },
   "fRMCJI": {
     "defaultMessage": "Prefill",

--- a/src/registry/textfield/edit.tsx
+++ b/src/registry/textfield/edit.tsx
@@ -26,7 +26,7 @@ import {
   useDeriveComponentKey,
 } from '@/components/builder';
 import {LABELS} from '@/components/builder/messages';
-import {Checkbox, Tab, TabList, TabPanel, Tabs, TextField} from '@/components/formio';
+import {Checkbox, Panel, Tab, TabList, TabPanel, Tabs, TextField} from '@/components/formio';
 import {useErrorChecker} from '@/utils/errors';
 
 import {EditFormDefinition} from '../types';
@@ -68,6 +68,10 @@ const EditForm: EditFormDefinition<TextFieldComponentSchema> = () => {
             'showCharCount'
           )}
         />
+        <BuilderTabs.Advanced hasErrors={hasAnyError('conditional')} />
+        <BuilderTabs.Validation hasErrors={hasAnyError('validate')} />
+        <BuilderTabs.Registration hasErrors={hasAnyError('registration')} />
+        <BuilderTabs.Prefill hasErrors={hasAnyError('prefill')} />
         <Tab
           hasErrors={hasAnyError(
             'deriveStreetName',
@@ -81,10 +85,6 @@ const EditForm: EditFormDefinition<TextFieldComponentSchema> = () => {
             defaultMessage="Location"
           />
         </Tab>
-        <BuilderTabs.Advanced hasErrors={hasAnyError('conditional')} />
-        <BuilderTabs.Validation hasErrors={hasAnyError('validate')} />
-        <BuilderTabs.Registration hasErrors={hasAnyError('registration')} />
-        <BuilderTabs.Prefill hasErrors={hasAnyError('prefill')} />
         <BuilderTabs.Translations hasErrors={hasAnyError('openForms.translations')} />
       </TabList>
 
@@ -104,14 +104,6 @@ const EditForm: EditFormDefinition<TextFieldComponentSchema> = () => {
         <ReadOnly />
         <Placeholder />
         <ShowCharCount />
-      </TabPanel>
-
-      {/* Location tab */}
-      <TabPanel>
-        <DeriveStreetName />
-        <DeriveCity />
-        <DerivePostcode />
-        <DeriveHouseNumber />
       </TabPanel>
 
       {/* Advanced tab */}
@@ -136,6 +128,33 @@ const EditForm: EditFormDefinition<TextFieldComponentSchema> = () => {
       {/* Prefill tab */}
       <TabPanel>
         <Prefill.PrefillConfiguration />
+      </TabPanel>
+
+      {/* Location tab */}
+      <TabPanel>
+        <p>
+          <i className="fa fa-circle-info" />
+          &nbsp;
+          <FormattedMessage
+            description="Location tab deprecation message"
+            defaultMessage="Deriving the location via text fields is deprecated. Use the AddressNL component instead."
+          />
+        </p>
+        <Panel
+          title={
+            <FormattedMessage
+              description="Legacy text field location configuration"
+              defaultMessage="Configuration (deprecated)"
+            />
+          }
+          collapsible
+          initialCollapsed
+        >
+          <DeriveStreetName />
+          <DeriveCity />
+          <DerivePostcode />
+          <DeriveHouseNumber />
+        </Panel>
       </TabPanel>
 
       {/* Translations */}


### PR DESCRIPTION
Update the builder to steer people to the new component instead of using the legacy configuration.