### PR TITLE
Issue/4637 optional translations act as required

### DIFF
--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -1204,6 +1204,21 @@ export const SelectBoxes: Story = {
       // check that the option labels are in the translations table
       expect(await editForm.findByText('Option label 1')).toBeVisible();
       expect(await editForm.findByText('Second option')).toBeVisible();
+
+      // Check that all translations can be filled
+      const inputs = editForm.getAllByRole('textbox');
+      for (let input of inputs) {
+        await userEvent.type(input, 'manualTranslation');
+        await expect(input).toHaveValue('manualTranslation');
+        await userEvent.clear(input);
+        await expect(input).toHaveValue('');
+      }
+
+      // Removing focus from the last input
+      await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
+
+      // Check that none of the inputs have a Required error message
+      await expect(await editForm.queryByText('Required')).toBeNull();
     });
 
     await step('Set up itemsExpression for options', async () => {
@@ -1239,7 +1254,9 @@ export const SelectBoxes: Story = {
         openForms: {
           dataSrc: 'variable',
           itemsExpression: {var: 'someVar'},
-          translations: {},
+          translations: {
+            nl: {description: '', label: '', tooltip: ''},
+          },
         },
         defaultValue: {},
         // Advanced tab
@@ -1410,6 +1427,21 @@ export const Radio: Story = {
       // check that the option labels are in the translations table
       expect(await editForm.findByText('Option label 1')).toBeVisible();
       expect(await editForm.findByText('Second option')).toBeVisible();
+
+      // Check that all translations can be filled
+      const inputs = editForm.getAllByRole('textbox');
+      for (let input of inputs) {
+        await userEvent.type(input, 'manualTranslation');
+        await expect(input).toHaveValue('manualTranslation');
+        await userEvent.clear(input);
+        await expect(input).toHaveValue('');
+      }
+
+      // Removing focus from the last input
+      await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
+
+      // Check that none of the inputs have a Required error message
+      await expect(await editForm.queryByText('Required')).toBeNull();
     });
 
     await step('Set up itemsExpression for options', async () => {
@@ -1445,7 +1477,9 @@ export const Radio: Story = {
         openForms: {
           dataSrc: 'variable',
           itemsExpression: {var: 'someVar'},
-          translations: {},
+          translations: {
+            nl: {description: '', label: '', tooltip: ''},
+          },
         },
         defaultValue: '',
         // Advanced tab
@@ -1623,6 +1657,21 @@ export const Select: Story = {
       // check that the option labels are in the translations table
       expect(await editForm.findByText('Option label 1')).toBeVisible();
       expect(await editForm.findByText('Second option')).toBeVisible();
+
+      // Check that all translations can be filled
+      const inputs = editForm.getAllByRole('textbox');
+      for (let input of inputs) {
+        await userEvent.type(input, 'manualTranslation');
+        await expect(input).toHaveValue('manualTranslation');
+        await userEvent.clear(input);
+        await expect(input).toHaveValue('');
+      }
+
+      // Removing focus from the last input
+      await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
+
+      // Check that none of the inputs have a Required error message
+      await expect(await editForm.queryByText('Required')).toBeNull();
     });
 
     await step('Set up itemsExpression for options', async () => {
@@ -1665,7 +1714,9 @@ export const Select: Story = {
         openForms: {
           dataSrc: 'variable',
           itemsExpression: {var: 'someVar'},
-          translations: {},
+          translations: {
+            nl: {description: '', label: '', tooltip: ''},
+          },
         },
         defaultValue: '',
         // Advanced tab

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -974,8 +974,10 @@ export const FileUpload: Story = {
     await step('File tab', async () => {
       await userEvent.click(canvas.getByRole('link', {name: 'File'}));
 
-      await expect(canvas.getByLabelText('Maximum file size')).toHaveDisplayValue('10MB');
-      await expect(canvas.getByText('Note that the server upload limit is 50MB.')).toBeVisible();
+      await waitFor(async () => {
+        await expect(canvas.getByLabelText('Maximum file size')).toHaveDisplayValue('10MB');
+        await expect(canvas.getByText('Note that the server upload limit is 50MB.')).toBeVisible();
+      });
 
       // check that the file types are visible
       canvas.getByLabelText('File types').focus();
@@ -1209,16 +1211,16 @@ export const SelectBoxes: Story = {
       const inputs = editForm.getAllByRole('textbox');
       for (let input of inputs) {
         await userEvent.type(input, 'manualTranslation');
-        await expect(input).toHaveValue('manualTranslation');
+        expect(input).toHaveValue('manualTranslation');
         await userEvent.clear(input);
-        await expect(input).toHaveValue('');
+        expect(input).toHaveValue('');
       }
 
       // Removing focus from the last input
       await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
 
       // Check that none of the inputs have a Required error message
-      await expect(await editForm.queryByText('Required')).toBeNull();
+      expect(await editForm.queryByText('Required')).toBeNull();
     });
 
     await step('Set up itemsExpression for options', async () => {

--- a/src/registry/addressNL/edit.stories.ts
+++ b/src/registry/addressNL/edit.stories.ts
@@ -35,10 +35,12 @@ export const PostcodeValidationTabWithoutConfiguration: Story = {
     await step('Navigate to validation tab and open Postcode validation', async () => {
       await userEvent.click(canvas.getByRole('link', {name: 'Validation'}));
       await userEvent.click(canvas.getAllByText('Postcode')[0]);
+
       expect(await canvas.findByLabelText('Regular expression for postcode')).toBeVisible();
       expect(await canvas.findByText('NL')).toBeVisible();
       expect(await canvas.findByText('EN')).toBeVisible();
       expect(await canvas.findByText('Error code')).toBeVisible();
+
       const errorMessageInput = await canvas.findByLabelText('Error message for "pattern"');
       expect(errorMessageInput).toHaveDisplayValue('');
     });
@@ -53,10 +55,12 @@ export const CityValidationTabWithoutConfiguration: Story = {
     await step('Navigate to validation tab and open City validation', async () => {
       await userEvent.click(canvas.getByRole('link', {name: 'Validation'}));
       await userEvent.click(canvas.getAllByText('City')[0]);
+
       expect(await canvas.findByLabelText('Regular expression for city')).toBeVisible();
       expect(await canvas.findByText('NL')).toBeVisible();
       expect(await canvas.findByText('EN')).toBeVisible();
       expect(await canvas.findByText('Error code')).toBeVisible();
+
       const errorMessageInput = await canvas.findByLabelText('Error message for "pattern"');
       expect(errorMessageInput).toHaveDisplayValue('');
     });
@@ -93,6 +97,7 @@ export const PostcodeValidationTabWithConfiguration: Story = {
       await userEvent.click(canvas.getByRole('link', {name: 'Validation'}));
       await userEvent.click(canvas.getAllByText('Postcode')[0]);
       const patternInput = await canvas.findByLabelText('Regular expression for postcode');
+
       expect(patternInput).toBeVisible();
       expect(patternInput).toHaveValue('1017 [A-Za-z]{2}');
 
@@ -136,6 +141,7 @@ export const CityValidationTabWithConfiguration: Story = {
       await userEvent.click(canvas.getByRole('link', {name: 'Validation'}));
       await userEvent.click(canvas.getAllByText('City')[0]);
       const patternInput = await canvas.findByLabelText('Regular expression for city');
+
       expect(patternInput).toBeVisible();
       expect(patternInput).toHaveValue('Amsterdam');
 

--- a/src/registry/radio/radio-validation.stories.ts
+++ b/src/registry/radio/radio-validation.stories.ts
@@ -57,3 +57,30 @@ export const ManualMinimumOneValue: Story = {
     });
   },
 };
+
+export const TranslationsArentRequired: Story = {
+  name: 'Translations: translations aren\'t required fields',
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await step('Translations aren\'t required fields', async () => {
+      await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
+      const editForm = within(canvas.getByTestId('componentEditForm'));
+
+      // Check that all translations can be filled
+      const inputs = editForm.getAllByRole('textbox');
+      for (let input of inputs) {
+        await userEvent.type(input, 'manualTranslation');
+        await expect(input).toHaveValue('manualTranslation');
+        await userEvent.clear(input);
+        await expect(input).toHaveValue('');
+      }
+
+      // Removing focus from the last input
+      await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
+
+      // Check that none of the inputs have a Required error message
+      await expect(await editForm.queryByText('Required')).toBeNull();
+    });
+  },
+};

--- a/src/registry/radio/radio-validation.stories.ts
+++ b/src/registry/radio/radio-validation.stories.ts
@@ -52,18 +52,19 @@ export const ManualMinimumOneValue: Story = {
       await userEvent.type(labelInput, 'Foo');
       await userEvent.clear(labelInput);
       await userEvent.keyboard('[Tab]');
-      await expect(await canvas.findByText('The option label is a required field.')).toBeVisible();
-      await expect(await canvas.findByText('The option value is a required field.')).toBeVisible();
+
+      expect(await canvas.findByText('The option label is a required field.')).toBeVisible();
+      expect(await canvas.findByText('The option value is a required field.')).toBeVisible();
     });
   },
 };
 
 export const TranslationsArentRequired: Story = {
-  name: 'Translations: translations aren\'t required fields',
+  name: "Translations: translations aren't required fields",
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
-    await step('Translations aren\'t required fields', async () => {
+    await step("Translations aren't required fields", async () => {
       await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
       const editForm = within(canvas.getByTestId('componentEditForm'));
 
@@ -71,16 +72,16 @@ export const TranslationsArentRequired: Story = {
       const inputs = editForm.getAllByRole('textbox');
       for (let input of inputs) {
         await userEvent.type(input, 'manualTranslation');
-        await expect(input).toHaveValue('manualTranslation');
+        expect(input).toHaveValue('manualTranslation');
         await userEvent.clear(input);
-        await expect(input).toHaveValue('');
+        expect(input).toHaveValue('');
       }
 
       // Removing focus from the last input
       await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
 
       // Check that none of the inputs have a Required error message
-      await expect(await editForm.queryByText('Required')).toBeNull();
+      expect(await editForm.queryByText('Required')).toBeNull();
     });
   },
 };

--- a/src/registry/select/select-validation.spec.tsx
+++ b/src/registry/select/select-validation.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import ComponentEditForm from '@/components/ComponentEditForm';
 import {contextRender, screen} from '@/tests/test-utils';
+import {expect, within} from '@storybook/test';
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -95,4 +96,60 @@ test('There is always at least one option', async () => {
   // wait for first value to be added
   const firstValueLabel = await screen.findByTestId('input-data.values[0].label');
   expect(firstValueLabel).toBeVisible();
+});
+
+test('All translations are optional', async () => {
+  const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+  const onSubmit = jest.fn();
+  const component = {
+    id: 'wqimsadk',
+    type: 'select',
+    key: 'select',
+    label: 'A select field',
+    dataSrc: 'values',
+    openForms: {
+      dataSrc: 'manual',
+      translations: {},
+    },
+    data: {
+      values: [],
+    },
+    defaultValue: '',
+  } satisfies SelectComponentSchema;
+
+  const builderInfo = {
+    title: 'Select',
+    icon: 'th-list',
+    group: 'basic',
+    weight: 70,
+    schema: {},
+  };
+  contextRender(
+    <ComponentEditForm
+      isNew
+      component={component}
+      builderInfo={builderInfo}
+      onCancel={jest.fn()}
+      onRemove={jest.fn()}
+      onSubmit={onSubmit}
+    />
+  );
+
+  await user.click(screen.getByRole('tab', {name: 'Translations'}));
+  const editForm = within(screen.getByTestId('componentEditForm'));
+
+  // Check that all translations can be filled
+  const inputs = editForm.getAllByRole('textbox');
+  for (let input of inputs) {
+    await user.type(input, 'manualTranslation');
+    await expect(input).toHaveValue('manualTranslation');
+    await user.clear(input);
+    await expect(input).toHaveValue('');
+  }
+
+  // Removing focus from the last input
+  await user.click(screen.getByRole('tab', {name: 'Translations'}));
+
+  // Check that none of the inputs have a Required error message
+  await expect(await editForm.queryByText('Required')).toBeNull();
 });

--- a/src/registry/select/select-validation.spec.tsx
+++ b/src/registry/select/select-validation.spec.tsx
@@ -1,9 +1,9 @@
 import {SelectComponentSchema} from '@open-formulieren/types';
+import {expect, within} from '@storybook/test';
 import userEvent from '@testing-library/user-event';
 
 import ComponentEditForm from '@/components/ComponentEditForm';
 import {contextRender, screen} from '@/tests/test-utils';
-import {expect, within} from '@storybook/test';
 
 beforeAll(() => {
   jest.useFakeTimers();

--- a/src/registry/selectboxes/selectboxes-validation.stories.ts
+++ b/src/registry/selectboxes/selectboxes-validation.stories.ts
@@ -73,11 +73,11 @@ export const ManualMinimumOneValue: Story = {
 };
 
 export const TranslationsArentRequired: Story = {
-  name: 'Translations: translations aren\'t required fields',
+  name: "Translations: translations aren't required fields",
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
-    await step('Translations aren\'t required fields', async () => {
+    await step("Translations aren't required fields", async () => {
       await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
       const editForm = within(canvas.getByTestId('componentEditForm'));
 

--- a/src/registry/selectboxes/selectboxes-validation.stories.ts
+++ b/src/registry/selectboxes/selectboxes-validation.stories.ts
@@ -72,6 +72,33 @@ export const ManualMinimumOneValue: Story = {
   },
 };
 
+export const TranslationsArentRequired: Story = {
+  name: 'Translations: translations aren\'t required fields',
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await step('Translations aren\'t required fields', async () => {
+      await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
+      const editForm = within(canvas.getByTestId('componentEditForm'));
+
+      // Check that all translations can be filled
+      const inputs = editForm.getAllByRole('textbox');
+      for (let input of inputs) {
+        await userEvent.type(input, 'manualTranslation');
+        await expect(input).toHaveValue('manualTranslation');
+        await userEvent.clear(input);
+        await expect(input).toHaveValue('');
+      }
+
+      // Removing focus from the last input
+      await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
+
+      // Check that none of the inputs have a Required error message
+      await expect(await editForm.queryByText('Required')).toBeNull();
+    });
+  },
+};
+
 export const MinAndMaxSelectedInitialValues: Story = {
   name: 'Initial min and max count',
   args: {

--- a/src/registry/validation.ts
+++ b/src/registry/validation.ts
@@ -84,7 +84,7 @@ export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
 
 // Maps to @open-formulieren/types common.ts Option type.
 const optionTranslationSchema = z.object({
-  label: z.string(),
+  label: z.string().optional(),
 });
 
 export const optionSchema = (intl: IntlShape) =>
@@ -109,7 +109,7 @@ export const optionSchema = (intl: IntlShape) =>
       .object({
         // zod doesn't seem to be able to use our supportedLanguageCodes for z.object keys,
         // they need to be defined statically. So, 'record' it is.
-        translations: z.record(optionTranslationSchema.optional()),
+        translations: z.record(z.string(), optionTranslationSchema.optional()),
       })
       .optional(),
   });


### PR DESCRIPTION
The translations of the option values where required because of a small issue in the zog validation configuration. This is now fixed

I've also added some tests to the componentConfigurations story, and to the stories of the individual components. Each story now has tests for the translation inputs. Ensuring that all translation inputs can be targeted, filled in, cleared and result in no errors.