### PR TITLE
:bug: [open-formulieren/open-forms#4772] Set select dataType to string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@formatjs/cli": "^6.1.1",
         "@formatjs/ts-transformer": "^3.12.0",
         "@fortawesome/fontawesome-free": "^6.4.0",
-        "@open-formulieren/types": "^0.33.0",
+        "@open-formulieren/types": "^0.34.0",
         "@storybook/addon-actions": "^8.3.5",
         "@storybook/addon-essentials": "^8.3.5",
         "@storybook/addon-interactions": "^8.3.5",
@@ -5087,9 +5087,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.33.0.tgz",
-      "integrity": "sha512-ALPg3wMviAxmfdXBBfaSkecZH92yfbH+EXUiyByiDo8WtJHGbniiXSV6YHMWvrXFWuKxCTx22St0wl/if0Ojjw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.34.0.tgz",
+      "integrity": "sha512-4MGJdllKYqcKMNRvJSTn+wIu8v0LB1dxfYNK5CV+6y751GN/Ss8sbEbfO69nYvO92zFs1b3NgQ63I6pQC8THMg==",
       "dev": true,
       "license": "EUPL-1.2"
     },
@@ -24607,9 +24607,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.33.0.tgz",
-      "integrity": "sha512-ALPg3wMviAxmfdXBBfaSkecZH92yfbH+EXUiyByiDo8WtJHGbniiXSV6YHMWvrXFWuKxCTx22St0wl/if0Ojjw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-0.34.0.tgz",
+      "integrity": "sha512-4MGJdllKYqcKMNRvJSTn+wIu8v0LB1dxfYNK5CV+6y751GN/Ss8sbEbfO69nYvO92zFs1b3NgQ63I6pQC8THMg==",
       "dev": true
     },
     "@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@formatjs/cli": "^6.1.1",
     "@formatjs/ts-transformer": "^3.12.0",
     "@fortawesome/fontawesome-free": "^6.4.0",
-    "@open-formulieren/types": "^0.33.0",
+    "@open-formulieren/types": "^0.34.0",
     "@storybook/addon-actions": "^8.3.5",
     "@storybook/addon-essentials": "^8.3.5",
     "@storybook/addon-interactions": "^8.3.5",

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -1626,6 +1626,7 @@ export const Select: Story = {
         clearOnHide: true,
         isSensitiveData: false,
         dataSrc: 'values',
+        dataType: 'string',
         data: {
           values: [
             {
@@ -1726,6 +1727,7 @@ export const Select: Story = {
         clearOnHide: true,
         isSensitiveData: false,
         dataSrc: 'values',
+        dataType: 'string',
         data: {},
         openForms: {
           dataSrc: 'variable',

--- a/src/registry/select/edit.tsx
+++ b/src/registry/select/edit.tsx
@@ -177,6 +177,7 @@ EditForm.defaultValues = {
   // fixed, this is what itemsExpression results in via the backend. Do not confuse with
   // openForms.dataSrc!
   dataSrc: 'values',
+  dataType: 'string',
   data: {values: [{value: '', label: ''}]},
   // TODO: at some point we can allow an itemsExpression for this too
   // Note: Formio will override this to `null`! So be careful when dealing with


### PR DESCRIPTION
Fixes open-formulieren/open-forms#4772 partially

Requires https://github.com/open-formulieren/types/pull/58 to be merged/released/bumped

because Select components did not have a dataType set, formio tries to cast it to other types if possible, which causes issues when submitting the data to the backend. For that reason we set the value to string to avoid this unwanted normalization
