### PR TITLE
Handle API serializer renames in the backend

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -24,9 +24,9 @@ export interface SelectOption {
  */
 export interface DocumentTypeOption {
   backendLabel: string;
-  catalogusLabel: string;
+  catalogueLabel: string;
   url: string;
-  omschrijving: string;
+  description: string;
 }
 
 /*

--- a/src/registry/file/registration-tab.tsx
+++ b/src/registry/file/registration-tab.tsx
@@ -15,11 +15,11 @@ interface DocumentTypeOptionsGroup {
 
 const groupDocumentTypeOptions = (options: DocumentTypeOption[]): DocumentTypeOptionsGroup[] => {
   const optionsWithGroupLabel = options.map(item => {
-    const groupLabel = [item.backendLabel, item.catalogusLabel].filter(Boolean).join(' > ');
+    const groupLabel = [item.backendLabel, item.catalogueLabel].filter(Boolean).join(' > ');
     return {
       groupLabel,
       value: item.url,
-      label: item.omschrijving,
+      label: item.description,
     };
   });
 

--- a/src/tests/sharedUtils.tsx
+++ b/src/tests/sharedUtils.tsx
@@ -125,28 +125,28 @@ export const DEFAULT_FILE_TYPES: SelectOption[] = [
 export const DEFAULT_DOCUMENT_TYPES: DocumentTypeOption[] = [
   {
     backendLabel: '',
-    catalogusLabel: 'VTH (RSIN: 000000000)',
+    catalogueLabel: 'VTH (RSIN: 000000000)',
     url: 'https://example.com/iotype/123',
-    omschrijving: 'Vergunning',
+    description: 'Vergunning',
   },
   {
     backendLabel: 'Open Zaak',
-    catalogusLabel: 'VTH (RSIN: 000000000)',
+    catalogueLabel: 'VTH (RSIN: 000000000)',
 
     url: 'https://example.com/iotype/456',
-    omschrijving: 'Vergunning',
+    description: 'Vergunning',
   },
   {
     backendLabel: 'Open Zaak',
-    catalogusLabel: 'VTH (RSIN: 000000000)',
+    catalogueLabel: 'VTH (RSIN: 000000000)',
     url: 'https://example.com/iotype/789',
-    omschrijving: 'Ontheffing',
+    description: 'Ontheffing',
   },
   {
     backendLabel: 'Open Zaak',
-    catalogusLabel: 'Test catalogus name',
+    catalogueLabel: 'Test catalogus name',
     url: 'https://example.com/iotype/abc',
-    omschrijving: 'Aanvraag',
+    description: 'Aanvraag',
   },
 ];
 


### PR DESCRIPTION
Part of open-formulieren/open-forms#4606 - needs to be part of open-formulieren/open-forms#4817

The backend makes the API serializers more uniformly English in 3.0