### PR TITLE
:sparkles: [open-formulieren/open-forms#5025] Use generally configured filetypes by default

### DIFF
--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -1047,7 +1047,7 @@ export const FileUpload: Story = {
           allowedTypesLabels: ['.jpg'], // derived from file.type
         },
         filePattern: 'image/jpeg', // derived from file.type
-        useConfigFiletypes: false,
+        useConfigFiletypes: true,
         of: {
           image: {
             resize: {

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -168,7 +168,7 @@ EditForm.defaultValues = {
     allowedTypesLabels: [],
   },
   filePattern: '*',
-  useConfigFiletypes: false,
+  useConfigFiletypes: true,
   of: {
     image: {
       resize: {


### PR DESCRIPTION
closes open-formulieren/open-forms#5025 partially (will also have to be released + updated in the backend)