### PR TITLE
Removing zIndex from required field asterisks

### DIFF
--- a/src/components/formio/component-label.scss
+++ b/src/components/formio/component-label.scss
@@ -1,0 +1,5 @@
+.field-required {
+  &:after {
+    z-index: unset;
+  }
+}

--- a/src/components/formio/component-label.tsx
+++ b/src/components/formio/component-label.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
 
+import './component-label.scss';
 import Tooltip from './tooltip';
 
 export interface ComponentLabelProps {


### PR DESCRIPTION
Closes open-formulieren/open-forms#5105

~The asterisks on required fields have a z-index of 10. This is part of base formio styling, so no idea why this is. Instead of lowering this, I've opted to raise the select component menu.~

Edit: So I've changed this to indeed remove the z-index from the required field asterisks. Raising the select menu is also an option, but that scares me a bit more