### PR TITLE
Catching component preview errors

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -599,6 +599,11 @@
     "description": "Column mobile size table header/label",
     "originalDefault": "Size (mobile)"
   },
+  "KMs17v": {
+    "defaultMessage": "Unfortunately something went wrong!",
+    "description": "Generic error message",
+    "originalDefault": "Unfortunately something went wrong!"
+  },
   "Kdgpxf": {
     "defaultMessage": "Longitude coordinate of the initial center point of the map.",
     "description": "Tooltip for 'initialCenter.lng' builder field",
@@ -613,6 +618,11 @@
     "defaultMessage": "The maximum number of files that can be uploaded.",
     "description": "Tooltip for 'maxNumberOfFiles' builder field",
     "originalDefault": "The maximum number of files that can be uploaded."
+  },
+  "KvSkZT": {
+    "defaultMessage": "Oops!",
+    "description": "Error boundary title",
+    "originalDefault": "Oops!"
   },
   "KwatvH": {
     "defaultMessage": "The number of rows for this text area.",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -607,6 +607,11 @@
     "description": "Column mobile size table header/label",
     "originalDefault": "Size (mobile)"
   },
+  "KMs17v": {
+    "defaultMessage": "Unfortunately something went wrong!",
+    "description": "Generic error message",
+    "originalDefault": "Unfortunately something went wrong!"
+  },
   "Kdgpxf": {
     "defaultMessage": "Longitudecoordinaat waarop de kaart gecentreerd wordt.",
     "description": "Tooltip for 'initialCenter.lng' builder field",
@@ -621,6 +626,11 @@
     "defaultMessage": "Het maximaal aantal bestanden die mogen geüpload worden.",
     "description": "Tooltip for 'maxNumberOfFiles' builder field",
     "originalDefault": "The maximum number of files that can be uploaded."
+  },
+  "KvSkZT": {
+    "defaultMessage": "Oops!",
+    "description": "Error boundary title",
+    "originalDefault": "Oops!"
   },
   "KwatvH": {
     "defaultMessage": "Het aantal regels voor dit tekstvlak.",

--- a/src/components/ComponentPreview.tsx
+++ b/src/components/ComponentPreview.tsx
@@ -4,10 +4,11 @@ import {Formik} from 'formik';
 import React, {useContext, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
-import PreviewModeToggle, {PreviewState} from '@/components/PreviewModeToggle';
+import PreviewModeToggle, {type PreviewState} from '@/components/PreviewModeToggle';
+import ErrorBoundary from '@/components/error/ErrorBoundary';
 import {BuilderContext} from '@/context';
 import {getRegistryEntry} from '@/registry';
-import {AnyComponentSchema, hasOwnProperty} from '@/types';
+import {type AnyComponentSchema, hasOwnProperty} from '@/types';
 
 /*
   Generic preview (preview + wrapper with view mode)
@@ -60,7 +61,7 @@ const ComponentPreviewWrapper: React.FC<ComponentPreviewWrapperProps> = ({
               className={clsx('component-preview', `component-preview--${component.type}`)}
               data-testid="componentPreview"
             >
-              {children}
+              <ErrorBoundary>{children}</ErrorBoundary>
             </div>
           </Formik>
         </div>

--- a/src/components/error/ErrorBoundary.stories.tsx
+++ b/src/components/error/ErrorBoundary.stories.tsx
@@ -1,26 +1,19 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 
 import ErrorBoundary from './ErrorBoundary';
 
-const ThrowError = ({error}: {error: Error}) => {
+const ThrowError: React.FC<{error: Error}> = ({error}) => {
   throw error;
-};
-
-const render = () => {
-  const error = new Error('some error');
-  return (
-    <ErrorBoundary>
-      <ThrowError error={error} />
-    </ErrorBoundary>
-  );
 };
 
 export default {
   title: 'Generic/Error boundary',
-  render,
   component: ErrorBoundary,
   parameters: {
     modal: {noModal: true},
+  },
+  args: {
+    children: <ThrowError error={new Error('some error')} />,
   },
 } as Meta<typeof ErrorBoundary>;
 

--- a/src/components/error/ErrorBoundary.stories.tsx
+++ b/src/components/error/ErrorBoundary.stories.tsx
@@ -1,0 +1,29 @@
+import {Meta, StoryObj} from '@storybook/react';
+
+import ErrorBoundary from './ErrorBoundary';
+
+const ThrowError = ({error}: {error: Error}) => {
+  throw error;
+};
+
+const render = () => {
+  const error = new Error('some error');
+  return (
+    <ErrorBoundary>
+      <ThrowError error={error} />
+    </ErrorBoundary>
+  );
+};
+
+export default {
+  title: 'Generic/Error boundary',
+  render,
+  component: ErrorBoundary,
+  parameters: {
+    modal: {noModal: true},
+  },
+} as Meta<typeof ErrorBoundary>;
+
+type Story = StoryObj<typeof ErrorBoundary>;
+
+export const Default: Story = {};

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import GenericError from '@/components/error/GenericError';
+
+const logError = (error: Error, errorInfo: React.ErrorInfo) => {
+  console.error(error, errorInfo);
+};
+
+export interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface StateWithoutError {
+  hasError: false;
+  error: null;
+}
+
+interface StateWithError {
+  hasError: true;
+  error: Error;
+}
+
+type ErrorBoundaryState = StateWithError | StateWithoutError;
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {hasError: false, error: null};
+  }
+
+  static getDerivedStateFromError(error: Error): StateWithError {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    logError(error, errorInfo);
+  }
+
+  render(): React.ReactNode {
+    const {children} = this.props;
+    const {hasError, error} = this.state;
+    if (!hasError) {
+      return children;
+    }
+
+    return <GenericError error={error} />;
+  }
+}

--- a/src/components/error/GenericError.tsx
+++ b/src/components/error/GenericError.tsx
@@ -1,0 +1,27 @@
+import {FormattedMessage, useIntl} from 'react-intl';
+
+export interface GenericErrorProps {
+  error: Error;
+}
+
+const GenericError: React.FC<GenericErrorProps> = ({error}) => {
+  const intl = useIntl();
+  return (
+    <div
+      title={intl.formatMessage({
+        description: 'Error boundary title',
+        defaultMessage: 'Oops!',
+      })}
+    >
+      <div className="alert alert-danger">
+        <FormattedMessage
+          description="Generic error message"
+          defaultMessage="Unfortunately something went wrong!"
+        />
+      </div>
+      <p>{error.message}</p>
+    </div>
+  );
+};
+
+export default GenericError;

--- a/src/registry/map/map-configuration.tsx
+++ b/src/registry/map/map-configuration.tsx
@@ -49,6 +49,8 @@ const Latitude: React.FC = () => {
       }
       tooltip={tooltip}
       placeholder="52.1326332"
+      min={-90}
+      max={90}
     />
   );
 };
@@ -76,6 +78,8 @@ const Longitude: React.FC = () => {
       }
       tooltip={tooltip}
       placeholder="5.291266"
+      min={-180}
+      max={180}
     />
   );
 };


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5191

Adding a ErrorBoundary component, with generic error handling, to make sure that errors thrown in the component preview don't crash the component modal.