### PR TITLE
Added description to the map component zoom field

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -1274,6 +1274,11 @@
     "description": "Date field 'minDate' fixed value tooltip",
     "originalDefault": "The minimum date that can be picked."
   },
+  "lZp543": {
+    "defaultMessage": "Value in whole numbers, between 1 and 13.",
+    "description": "Description for 'defaultZoom' builder field",
+    "originalDefault": "Value in whole numbers, between 1 and 13."
+  },
   "loKqis": {
     "defaultMessage": "Partner 1",
     "description": "npFamilyMembers dummy option for partner",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -1289,6 +1289,11 @@
     "description": "Date field 'minDate' fixed value tooltip",
     "originalDefault": "The minimum date that can be picked."
   },
+  "lZp543": {
+    "defaultMessage": "Value in whole numbers, between 1 and 13.",
+    "description": "Description for 'defaultZoom' builder field",
+    "originalDefault": "Value in whole numbers, between 1 and 13."
+  },
   "loKqis": {
     "defaultMessage": "Partner 1",
     "description": "npFamilyMembers dummy option for partner",

--- a/src/registry/map/map-configuration.tsx
+++ b/src/registry/map/map-configuration.tsx
@@ -18,6 +18,12 @@ const DefaultZoom: React.FC = () => {
           defaultMessage="Zoom level"
         />
       }
+      description={
+        <FormattedMessage
+          description="Description for 'defaultZoom' builder field"
+          defaultMessage="Value in whole numbers, between 1 and 13."
+        />
+      }
       tooltip={tooltip}
       step={1}
       min={TILE_LAYER_RD.minZoom}


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5191

Added a description to the map component zoom field, to describe the valid values.