### PR TITLE
Update ESM imports

### DIFF
--- a/src/components/builder/prefill/attribute.tsx
+++ b/src/components/builder/prefill/attribute.tsx
@@ -1,8 +1,7 @@
 import {useField, useFormikContext} from 'formik';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
-import usePrevious from 'react-use/esm/usePrevious';
+import {useAsync, usePrevious} from 'react-use';
 
 import Select from '@/components/formio/select';
 import {BuilderContext} from '@/context';

--- a/src/components/builder/prefill/plugin.tsx
+++ b/src/components/builder/prefill/plugin.tsx
@@ -1,7 +1,7 @@
 import {useFormikContext} from 'formik';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import Select from '@/components/formio/select';
 import {BuilderContext} from '@/context';

--- a/src/components/builder/registration/registration-attribute.tsx
+++ b/src/components/builder/registration/registration-attribute.tsx
@@ -2,7 +2,7 @@ import {useFormikContext} from 'formik';
 import {ExtendedComponentSchema} from 'formiojs';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import Select from '@/components/formio/select';
 import {BuilderContext} from '@/context';

--- a/src/components/builder/simple-conditional.tsx
+++ b/src/components/builder/simple-conditional.tsx
@@ -4,7 +4,7 @@ import {Utils as FormioUtils} from 'formiojs';
 import type {ConditionalOptions} from 'formiojs';
 import {useContext, useEffect} from 'react';
 import {FormattedMessage} from 'react-intl';
-import usePrevious from 'react-use/esm/usePrevious';
+import {usePrevious} from 'react-use';
 
 import {TextField} from '@/components/formio/textfield';
 import {BuilderContext} from '@/context';

--- a/src/components/builder/validate/validator-select.tsx
+++ b/src/components/builder/validate/validator-select.tsx
@@ -2,7 +2,7 @@ import {useFormikContext} from 'formik';
 import {ExtendedComponentSchema} from 'formiojs';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {BuilderContext} from '@/context';
 

--- a/src/components/builder/values/reference-lists/code.tsx
+++ b/src/components/builder/values/reference-lists/code.tsx
@@ -1,7 +1,7 @@
 import {useFormikContext} from 'formik';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import Select from '@/components/formio/select';
 import {BuilderContext} from '@/context';

--- a/src/components/builder/values/reference-lists/service.tsx
+++ b/src/components/builder/values/reference-lists/service.tsx
@@ -1,7 +1,7 @@
 import {useFormikContext} from 'formik';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import Select from '@/components/formio/select';
 import {BuilderContext} from '@/context';

--- a/src/registry/cosignV1/edit.tsx
+++ b/src/registry/cosignV1/edit.tsx
@@ -1,7 +1,7 @@
 import {CosignV1ComponentSchema} from '@open-formulieren/types';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {
   BuilderTabs,

--- a/src/registry/file/file-tab.tsx
+++ b/src/registry/file/file-tab.tsx
@@ -3,7 +3,7 @@ import {useFormikContext} from 'formik';
 import {isEqual} from 'lodash';
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {Checkbox, Component, NumberField, Select, TextField} from '@/components/formio';
 import {BuilderContext} from '@/context';

--- a/src/registry/file/registration-tab.tsx
+++ b/src/registry/file/registration-tab.tsx
@@ -1,6 +1,6 @@
 import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {Select, TextField} from '@/components/formio';
 import {BuilderContext, DocumentTypeOption, SelectOption} from '@/context';

--- a/src/registry/map/edit-validation.ts
+++ b/src/registry/map/edit-validation.ts
@@ -1,5 +1,5 @@
 // Import direct from the tiles lib, otherwise Leaflet is needed in unit tests for CRS.
-import {TILE_LAYER_RD} from '@open-formulieren/leaflet-tools/lib/tiles';
+import {TILE_LAYER_RD} from '@open-formulieren/leaflet-tools/lib/tiles.js';
 import {IntlShape} from 'react-intl';
 import {z} from 'zod';
 

--- a/src/registry/map/edit.tsx
+++ b/src/registry/map/edit.tsx
@@ -2,7 +2,7 @@ import {MapComponentSchema} from '@open-formulieren/types';
 import {useFormikContext} from 'formik';
 import {useContext, useEffect} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {
   BuilderTabs,

--- a/src/registry/map/overlays.tsx
+++ b/src/registry/map/overlays.tsx
@@ -1,7 +1,7 @@
 import {FieldArray, type FieldArrayRenderProps, useField, useFormikContext} from 'formik';
 import {useContext, useLayoutEffect} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import Loader from '@/components/builder/loader';
 import {Component, Panel, Select, TextField} from '@/components/formio';

--- a/src/registry/map/preview.tsx
+++ b/src/registry/map/preview.tsx
@@ -12,7 +12,7 @@ import {
   useMap,
 } from 'react-leaflet';
 import {EditControl} from 'react-leaflet-draw';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import Loader from '@/components/builder/loader';
 import {Component, Description} from '@/components/formio';

--- a/src/registry/radio/preview.tsx
+++ b/src/registry/radio/preview.tsx
@@ -1,7 +1,7 @@
 import {RadioComponentSchema} from '@open-formulieren/types';
 import {useContext} from 'react';
 import {useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {ReferenceListsTableItem} from '@/components/builder/values/reference-lists/types';
 import {transformItems} from '@/components/builder/values/reference-lists/utils';

--- a/src/registry/select/preview.tsx
+++ b/src/registry/select/preview.tsx
@@ -1,7 +1,7 @@
 import {SelectComponentSchema} from '@open-formulieren/types';
 import {useContext} from 'react';
 import {useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {ReferenceListsTableItem} from '@/components/builder/values/reference-lists/types';
 import {transformItems} from '@/components/builder/values/reference-lists/utils';

--- a/src/registry/selectboxes/preview.tsx
+++ b/src/registry/selectboxes/preview.tsx
@@ -1,7 +1,7 @@
 import {SelectboxesComponentSchema} from '@open-formulieren/types';
 import {useContext} from 'react';
 import {useIntl} from 'react-intl';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 
 import {ReferenceListsTableItem} from '@/components/builder/values/reference-lists/types';
 import {transformItems} from '@/components/builder/values/reference-lists/utils';


### PR DESCRIPTION
Version `0.50.0` causes the `open-forms` build to currently (version `3.4.8`) fail, see the attached file for more information:

[build-log.txt](https://github.com/user-attachments/files/26715412/build-log.txt)
