### PR TITLE
JSON editor storybook mocking

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type {StorybookConfig} from '@storybook/react-vite';
+import {fileURLToPath} from 'node:url';
 
 const config: StorybookConfig = {
   core: {
@@ -28,10 +29,9 @@ const config: StorybookConfig = {
     // The Monaco JSON Editor is mocked with a textarea component (the one used before),
     // as it doesn't play well with Storybook.
     // @ts-ignore
-    config.resolve.alias['@open-formulieren/monaco-json-editor'] = new URL(
-      './__mocks__/mockedJsonEditor.tsx',
-      import.meta.url
-    ).pathname;
+    config.resolve.alias['@open-formulieren/monaco-json-editor'] = fileURLToPath(
+      new URL('./__mocks__/mockedJsonEditor.tsx', import.meta.url)
+    );
 
     return config;
   },


### PR DESCRIPTION
Closes #276

The previous mocking setup, using `new URL().pathname`, works differently across OS systems. The URLs are represented/encoded differently on macOS as on Linux systems, causing the path not to be resolved. Additionally, spaces or other special characters in the URL path can also cause issues with this setup.

By using `fileURLToPath` the URLs are 'correctly' decoded, and the mocking import can be resolved on a wider scale of systems/file structures.