### PR TITLE
Restore notice about textfield location derivation

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -819,6 +819,11 @@
     "description": "Component translations 'prefix' property label",
     "originalDefault": "Prefix"
   },
+  "Ob4chA": {
+    "defaultMessage": "The location derivation options have known usability problems and do not work when used inside repeating groups. We recommend that you use the 'AddressNL' component instead. Existing forms will continue to function as before, but this feature will not receive further improvements.",
+    "description": "Text field location support notice",
+    "originalDefault": "The location derivation options have known usability problems and do not work when used inside repeating groups. We recommend that you use the 'AddressNL' component instead. Existing forms will continue to function as before, but this feature will not receive further improvements."
+  },
   "OlHdZq": {
     "defaultMessage": "License plate",
     "description": "Licenseplate component type label",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -829,6 +829,11 @@
     "isTranslated": true,
     "originalDefault": "Prefix"
   },
+  "Ob4chA": {
+    "defaultMessage": "Er zijn bekende gebruiksproblemen bij de opties om locaties af te leiden en ze werken helemaal niet in herhalende groepen. We raden aan om in plaats hiervan het 'AddressNL'-component te gebruiken. Bestaande formulieren blijven werken zoals voorheen, maar deze functionaliteit hier wordt niet meer doorontwikkeld.",
+    "description": "Text field location support notice",
+    "originalDefault": "The location derivation options have known usability problems and do not work when used inside repeating groups. We recommend that you use the 'AddressNL' component instead. Existing forms will continue to function as before, but this feature will not receive further improvements."
+  },
   "OlHdZq": {
     "defaultMessage": "License plate",
     "description": "Licenseplate component type label",

--- a/src/registry/textfield/edit.tsx
+++ b/src/registry/textfield/edit.tsx
@@ -137,6 +137,17 @@ const EditForm: EditFormDefinition<TextFieldComponentSchema> = () => {
 
       {/* Location tab */}
       <TabPanel>
+        <div className="alert alert-info">
+          <FormattedMessage
+            description="Text field location support notice"
+            defaultMessage={`The location derivation options have known usability
+            problems and do not work when used inside repeating groups. We recommend
+            that you use the 'AddressNL' component instead. Existing forms will continue
+            to function as before, but this feature will not receive further improvements.
+          `}
+          />
+        </div>
+
         <Panel
           title={
             <FormattedMessage


### PR DESCRIPTION
Relates to open-formulieren/open-forms#4431

Nudge users towards using addressNL, assuming that all the issues with that component are resolved :-)

Let's wait with merging this until the addressNL component itself is finished.