### PR TITLE
Add builder configuration fields for new document type configuration

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -49,6 +49,11 @@
     "description": "Tooltip for 'saveRow' builder field",
     "originalDefault": "Set the text of the 'Save row' button."
   },
+  "/xFb1n": {
+    "defaultMessage": "The 'domein' attribute for the Catalogus resource in the Catalogi API.",
+    "description": "Tooltip for 'registration.documentType.catalogue.domain' builder field",
+    "originalDefault": "The 'domein' attribute for the Catalogus resource in the Catalogi API."
+  },
   "/yDnA3": {
     "defaultMessage": "Whether to show this value in the confirmation PDF",
     "description": "Tooltip for 'showInPDF' builder field",
@@ -99,6 +104,11 @@
     "description": "Label for 'validate.pattern' builder field",
     "originalDefault": "Regular Expression Pattern"
   },
+  "1andg+": {
+    "defaultMessage": "The 'rsin' attribute for the Catalogus resource in the Catalogi API.",
+    "description": "Tooltip for 'registration.documentType.catalogue.rsin' builder field",
+    "originalDefault": "The 'rsin' attribute for the Catalogus resource in the Catalogi API."
+  },
   "1pC7IP": {
     "defaultMessage": "Specify template for name of uploaded file(s). <code>'{{ fileName }}'</code> contains the original filename.",
     "description": "Tooltip for 'file.name' builder field",
@@ -113,6 +123,11 @@
     "defaultMessage": "When email address verification is enabled, the user must verify their email address before they can submit the form. This proves the email address exists and that they have access to the account.",
     "description": "Tooltip for email 'openForms.requireVerification' builder field",
     "originalDefault": "When email address verification is enabled, the user must verify their email address before they can submit the form. This proves the email address exists and that they have access to the account."
+  },
+  "2KY/BC": {
+    "defaultMessage": "Specify the document type to use for the file uploads when sending them to the Documents API. The direct URL references are replaced with references to the catalogue and document type description.",
+    "description": "Tooltip file component registration: document type configuration",
+    "originalDefault": "Specify the document type to use for the file uploads when sending them to the Documents API. The direct URL references are replaced with references to the catalogue and document type description."
   },
   "2Lg8Vc": {
     "defaultMessage": "Hide fieldset header",
@@ -168,6 +183,11 @@
     "defaultMessage": "CSS class",
     "description": "Label for 'customClass' builder field",
     "originalDefault": "CSS class"
+  },
+  "3leP68": {
+    "defaultMessage": "Document type",
+    "description": "File component registration: document type configuration",
+    "originalDefault": "Document type"
   },
   "4/cCvG": {
     "defaultMessage": "Location",
@@ -464,6 +484,11 @@
     "description": "Tooltip validation error translations panel",
     "originalDefault": "Custom error messages for this component and their translations"
   },
+  "DE7U4q": {
+    "defaultMessage": "The RSIN must consist of 9 numbers.",
+    "description": "File registration validation error for invalid RSIN pattern",
+    "originalDefault": "The RSIN must consist of 9 numbers."
+  },
   "DEetjI": {
     "defaultMessage": "Street name",
     "description": "Label for addressNL streetName read only result",
@@ -598,6 +623,11 @@
     "defaultMessage": "The component type <code>{type}</code> is unknown. We can only display the JSON definition.",
     "description": "Informational message about unsupported component",
     "originalDefault": "The component type <code>{type}</code> is unknown. We can only display the JSON definition."
+  },
+  "J1zTQz": {
+    "defaultMessage": "Document type description",
+    "description": "Label for 'registration.documentType.description' builder field",
+    "originalDefault": "Document type description"
   },
   "JDYF2q": {
     "defaultMessage": "The data entered in this component will be removed in accordance with the privacy settings.",
@@ -1089,10 +1119,20 @@
     "description": "Tooltip for 'showInSummary' builder field",
     "originalDefault": "Whether to show this value in the submission summary"
   },
+  "bh2ky5": {
+    "defaultMessage": "Catalogus domain",
+    "description": "Label for 'registration.documentType.catalogue.domain' builder field",
+    "originalDefault": "Catalogus domain"
+  },
   "bvY9oJ": {
     "defaultMessage": "Provide the key of a static, component, or user defined variable.",
     "description": "Tooltip for 'variable' in relative delta date constraint validation",
     "originalDefault": "Provide the key of a static, component, or user defined variable."
+  },
+  "c770ER": {
+    "defaultMessage": "Catalogus RSIN",
+    "description": "Label for 'registration.documentType.catalogue.rsin' builder field",
+    "originalDefault": "Catalogus RSIN"
   },
   "cAC5kL": {
     "defaultMessage": "Remove the value of this field from the submission if it is hidden. Note: the value of this field is then also not used in logic rules!",
@@ -1118,6 +1158,11 @@
     "defaultMessage": "Number of days. Empty values are ignored.",
     "description": "Tooltip for 'delta.days' in relative delta date constraint validation",
     "originalDefault": "Number of days. Empty values are ignored."
+  },
+  "ce0Nz4": {
+    "defaultMessage": "You must specify a document type description when a catalogue is configured.",
+    "description": "File registration validation error for missing document type description",
+    "originalDefault": "You must specify a document type description when a catalogue is configured."
   },
   "ce1N0I": {
     "defaultMessage": "Plugin",
@@ -1288,6 +1333,11 @@
     "defaultMessage": "Fieldset content",
     "description": "Fieldset preview content description",
     "originalDefault": "Fieldset content"
+  },
+  "hAc9vQ": {
+    "defaultMessage": "Legacy",
+    "description": "File component registration: legacy configuration",
+    "originalDefault": "Legacy"
   },
   "hEVgKd": {
     "defaultMessage": "Error message for \"{key}\"",
@@ -1504,6 +1554,11 @@
     "description": "Tooltip for 'useConfigDefaultMapSettings' builder field",
     "originalDefault": "When this is checked, the map component settings configured in the global configuration will be used."
   },
+  "oiB6Kg": {
+    "defaultMessage": "The direct URL configuration is scheduled for removal. If both the URL and the fields above are configured, the new configuration is used.",
+    "description": "Tooltip file component registration: legacy document type configuration",
+    "originalDefault": "The direct URL configuration is scheduled for removal. If both the URL and the fields above are configured, the new configuration is used."
+  },
   "osSl3z": {
     "defaultMessage": "City",
     "description": "Label for addressNL city read only result",
@@ -1649,6 +1704,11 @@
     "description": "Label for 'DeriveAddress' builder field",
     "originalDefault": "Derive address"
   },
+  "tzAOAm": {
+    "defaultMessage": "You must specify both domain and RSIN.",
+    "description": "File registration validation error for missing catalogue rsin or RSIN",
+    "originalDefault": "You must specify both domain and RSIN."
+  },
   "u5XYQh": {
     "defaultMessage": "Footer",
     "description": "Component property 'footer' label",
@@ -1663,6 +1723,11 @@
     "defaultMessage": "Translations",
     "description": "Component edit form tab title for 'Translations' tab",
     "originalDefault": "Translations"
+  },
+  "uOtaSP": {
+    "defaultMessage": "The document type will be retrieved in the specified catalogue. The version will automatically be selected based on the submission completion timestamp. When used with ZGW APIs, ensure that the document type belongs to the specified case type!",
+    "description": "Tooltip for 'registration.documentType.description' builder field",
+    "originalDefault": "The document type will be retrieved in the specified catalogue. The version will automatically be selected based on the submission completion timestamp. When used with ZGW APIs, ensure that the document type belongs to the specified case type!"
   },
   "uVVO4b": {
     "defaultMessage": "Error",
@@ -1724,6 +1789,11 @@
     "description": "Tooltip for 'validate.pattern' builder field",
     "originalDefault": "The regular expression pattern test that the field value must pass before the form can be submitted."
   },
+  "wqhr+0": {
+    "defaultMessage": "Specify either none or all three of the fields below to configure the document type to use.",
+    "description": "Description for 'registration.documentType' configuration",
+    "originalDefault": "Specify either none or all three of the fields below to configure the document type to use."
+  },
   "xI6md8": {
     "defaultMessage": "Add/subtract duration",
     "description": "Label for 'operator' in relative delta date constraint validation",
@@ -1733,6 +1803,11 @@
     "defaultMessage": "Email",
     "description": "Label for digital address email",
     "originalDefault": "Email"
+  },
+  "xUt2+r": {
+    "defaultMessage": "You must specify both domain and RSIN.",
+    "description": "File registration validation error for missing catalogue domain or RSIN",
+    "originalDefault": "You must specify both domain and RSIN."
   },
   "xrfkiI": {
     "defaultMessage": "Overlay: {overlayName}",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -49,6 +49,11 @@
     "description": "Tooltip for 'saveRow' builder field",
     "originalDefault": "Set the text of the 'Save row' button."
   },
+  "/xFb1n": {
+    "defaultMessage": "The 'domein' attribute for the Catalogus resource in the Catalogi API.",
+    "description": "Tooltip for 'registration.documentType.catalogue.domain' builder field",
+    "originalDefault": "The 'domein' attribute for the Catalogus resource in the Catalogi API."
+  },
   "/yDnA3": {
     "defaultMessage": "Geef aan of deze waarde in de (bevestigings-)PDF moet getoond worden. Deze PDF wordt vaak ook als bijlage meegestuurd tijdens de registratie.",
     "description": "Tooltip for 'showInPDF' builder field",
@@ -100,6 +105,11 @@
     "description": "Label for 'validate.pattern' builder field",
     "originalDefault": "Regular Expression Pattern"
   },
+  "1andg+": {
+    "defaultMessage": "The 'rsin' attribute for the Catalogus resource in the Catalogi API.",
+    "description": "Tooltip for 'registration.documentType.catalogue.rsin' builder field",
+    "originalDefault": "The 'rsin' attribute for the Catalogus resource in the Catalogi API."
+  },
   "1pC7IP": {
     "defaultMessage": "Specifieer een template voor de naam van het/de geüploade bestand(en). <code>'{{ fileName }}'</code> bevat de oorspronkelijke bestandsnaam.",
     "description": "Tooltip for 'file.name' builder field",
@@ -114,6 +124,11 @@
     "defaultMessage": "Wanneer e-mailadresverificatie ingeschakeld is, dan moet de gebruiker hun e-mail verifiëren voor ze het formulier kunnen insturen. Dit bewijst dat het e-mailadres geldig is en dat de gebruiker er toegang tot heeft.",
     "description": "Tooltip for email 'openForms.requireVerification' builder field",
     "originalDefault": "When email address verification is enabled, the user must verify their email address before they can submit the form. This proves the email address exists and that they have access to the account."
+  },
+  "2KY/BC": {
+    "defaultMessage": "Specify the document type to use for the file uploads when sending them to the Documents API. The direct URL references are replaced with references to the catalogue and document type description.",
+    "description": "Tooltip file component registration: document type configuration",
+    "originalDefault": "Specify the document type to use for the file uploads when sending them to the Documents API. The direct URL references are replaced with references to the catalogue and document type description."
   },
   "2Lg8Vc": {
     "defaultMessage": "Verberg veldengroepheader",
@@ -170,6 +185,11 @@
     "description": "Label for 'customClass' builder field",
     "isTranslated": true,
     "originalDefault": "CSS class"
+  },
+  "3leP68": {
+    "defaultMessage": "Document type",
+    "description": "File component registration: document type configuration",
+    "originalDefault": "Document type"
   },
   "4/cCvG": {
     "defaultMessage": "Locatie",
@@ -468,6 +488,11 @@
     "description": "Tooltip validation error translations panel",
     "originalDefault": "Custom error messages for this component and their translations"
   },
+  "DE7U4q": {
+    "defaultMessage": "The RSIN must consist of 9 numbers.",
+    "description": "File registration validation error for invalid RSIN pattern",
+    "originalDefault": "The RSIN must consist of 9 numbers."
+  },
   "DEetjI": {
     "defaultMessage": "Straatnaam",
     "description": "Label for addressNL streetName read only result",
@@ -605,6 +630,11 @@
     "defaultMessage": "Het componenttype <code>{type}</code> is niet bekend. We kunnen enkel de JSON-definitie weergeven.",
     "description": "Informational message about unsupported component",
     "originalDefault": "The component type <code>{type}</code> is unknown. We can only display the JSON definition."
+  },
+  "J1zTQz": {
+    "defaultMessage": "Document type description",
+    "description": "Label for 'registration.documentType.description' builder field",
+    "originalDefault": "Document type description"
   },
   "JDYF2q": {
     "defaultMessage": "Gegevens opgevoerd in dit component worden geschoond volgens de privacy-instellingen.",
@@ -1103,10 +1133,20 @@
     "description": "Tooltip for 'showInSummary' builder field",
     "originalDefault": "Whether to show this value in the submission summary"
   },
+  "bh2ky5": {
+    "defaultMessage": "Catalogus domain",
+    "description": "Label for 'registration.documentType.catalogue.domain' builder field",
+    "originalDefault": "Catalogus domain"
+  },
   "bvY9oJ": {
     "defaultMessage": "Geef de sleutel op van een vaste, veld- of zelfgedefinieerde variabele.",
     "description": "Tooltip for 'variable' in relative delta date constraint validation",
     "originalDefault": "Provide the key of a static, component, or user defined variable."
+  },
+  "c770ER": {
+    "defaultMessage": "Catalogus RSIN",
+    "description": "Label for 'registration.documentType.catalogue.rsin' builder field",
+    "originalDefault": "Catalogus RSIN"
   },
   "cAC5kL": {
     "defaultMessage": "Verwijder de waarde van dit veld van de inzending als dit veld verborgen is. Let op: De waarde van dit veld wordt dan ook niet gebruikt in logica regels!",
@@ -1132,6 +1172,11 @@
     "defaultMessage": "Aantal dagen. Lege waarden worden genegeerd.",
     "description": "Tooltip for 'delta.days' in relative delta date constraint validation",
     "originalDefault": "Number of days. Empty values are ignored."
+  },
+  "ce0Nz4": {
+    "defaultMessage": "You must specify a document type description when a catalogue is configured.",
+    "description": "File registration validation error for missing document type description",
+    "originalDefault": "You must specify a document type description when a catalogue is configured."
   },
   "ce1N0I": {
     "defaultMessage": "Plugin",
@@ -1305,6 +1350,11 @@
     "defaultMessage": "Veldengroepinhoud",
     "description": "Fieldset preview content description",
     "originalDefault": "Fieldset content"
+  },
+  "hAc9vQ": {
+    "defaultMessage": "Legacy",
+    "description": "File component registration: legacy configuration",
+    "originalDefault": "Legacy"
   },
   "hEVgKd": {
     "defaultMessage": "Foutmelding voor \"{key}\"",
@@ -1526,6 +1576,11 @@
     "description": "Tooltip for 'useConfigDefaultMapSettings' builder field",
     "originalDefault": "When this is checked, the map component settings configured in the global configuration will be used."
   },
+  "oiB6Kg": {
+    "defaultMessage": "The direct URL configuration is scheduled for removal. If both the URL and the fields above are configured, the new configuration is used.",
+    "description": "Tooltip file component registration: legacy document type configuration",
+    "originalDefault": "The direct URL configuration is scheduled for removal. If both the URL and the fields above are configured, the new configuration is used."
+  },
   "osSl3z": {
     "defaultMessage": "Stad",
     "description": "Label for addressNL city read only result",
@@ -1673,6 +1728,11 @@
     "description": "Label for 'DeriveAddress' builder field",
     "originalDefault": "Derive address"
   },
+  "tzAOAm": {
+    "defaultMessage": "You must specify both domain and RSIN.",
+    "description": "File registration validation error for missing catalogue rsin or RSIN",
+    "originalDefault": "You must specify both domain and RSIN."
+  },
   "u5XYQh": {
     "defaultMessage": "Voettekst",
     "description": "Component property 'footer' label",
@@ -1687,6 +1747,11 @@
     "defaultMessage": "Vertalingen",
     "description": "Component edit form tab title for 'Translations' tab",
     "originalDefault": "Translations"
+  },
+  "uOtaSP": {
+    "defaultMessage": "The document type will be retrieved in the specified catalogue. The version will automatically be selected based on the submission completion timestamp. When used with ZGW APIs, ensure that the document type belongs to the specified case type!",
+    "description": "Tooltip for 'registration.documentType.description' builder field",
+    "originalDefault": "The document type will be retrieved in the specified catalogue. The version will automatically be selected based on the submission completion timestamp. When used with ZGW APIs, ensure that the document type belongs to the specified case type!"
   },
   "uVVO4b": {
     "defaultMessage": "Fout",
@@ -1748,6 +1813,11 @@
     "description": "Tooltip for 'validate.pattern' builder field",
     "originalDefault": "The regular expression pattern test that the field value must pass before the form can be submitted."
   },
+  "wqhr+0": {
+    "defaultMessage": "Specify either none or all three of the fields below to configure the document type to use.",
+    "description": "Description for 'registration.documentType' configuration",
+    "originalDefault": "Specify either none or all three of the fields below to configure the document type to use."
+  },
   "xI6md8": {
     "defaultMessage": "Duur bijtellen/aftrekken",
     "description": "Label for 'operator' in relative delta date constraint validation",
@@ -1757,6 +1827,11 @@
     "defaultMessage": "E-mailadres",
     "description": "Label for digital address email",
     "originalDefault": "Email"
+  },
+  "xUt2+r": {
+    "defaultMessage": "You must specify both domain and RSIN.",
+    "description": "File registration validation error for missing catalogue domain or RSIN",
+    "originalDefault": "You must specify both domain and RSIN."
   },
   "xrfkiI": {
     "defaultMessage": "Laag: {overlayName}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@formio/vanilla-text-mask": "^5.1.1",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
-        "@open-formulieren/types": "^1.1.0",
+        "@open-formulieren/types": "^1.2.0",
         "ckeditor5": "^47.6.1",
         "clsx": "^1.2.1",
         "dompurify": "^3.3.3",
@@ -2998,9 +2998,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-ihgy4Lrdk5Wt+uHMT1BfdNvbOCzOvWWoCCmMUQ6ByXVF2Su5AxC6HoMsc8WhhP3jrLACIyCEFqkEQKAQsTmuEA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-4G3XDPC1uncrRen7kxEJhISNtWFhB381/5wKheQurBIKzE9P8q8KQNUzsTCGTVjMjElnUvN4QskUeZyJV9ij0w==",
       "license": "EUPL-1.2"
     },
     "node_modules/@parcel/watcher": {
@@ -15846,9 +15846,9 @@
       }
     },
     "@open-formulieren/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-ihgy4Lrdk5Wt+uHMT1BfdNvbOCzOvWWoCCmMUQ6ByXVF2Su5AxC6HoMsc8WhhP3jrLACIyCEFqkEQKAQsTmuEA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-4G3XDPC1uncrRen7kxEJhISNtWFhB381/5wKheQurBIKzE9P8q8KQNUzsTCGTVjMjElnUvN4QskUeZyJV9ij0w=="
     },
     "@parcel/watcher": {
       "version": "2.5.6",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@formio/vanilla-text-mask": "^5.1.1",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
-    "@open-formulieren/types": "^1.1.0",
+    "@open-formulieren/types": "^1.2.0",
     "ckeditor5": "^47.6.1",
     "clsx": "^1.2.1",
     "dompurify": "^3.3.3",

--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -1093,6 +1093,13 @@ export const FileUpload: Story = {
         maxNumberOfFiles: null,
         // registration tab
         registration: {
+          documentType: {
+            catalogue: {
+              domain: '',
+              rsin: '',
+            },
+            description: '',
+          },
           informatieobjecttype: '',
           bronorganisatie: '',
           docVertrouwelijkheidaanduiding: '',

--- a/src/registry/file/edit-validation.ts
+++ b/src/registry/file/edit-validation.ts
@@ -68,11 +68,76 @@ const buildFileMaxSizeSchema = (intl: IntlShape, builderContext: BuilderContextT
     });
 };
 
+const buildRegistrationSchema = (intl: IntlShape) =>
+  z.object({
+    documentType: z
+      .object({
+        catalogue: z.object({
+          domain: z.string().optional(),
+          rsin: z.string().optional(),
+        }),
+        description: z.string().optional(),
+      })
+      .optional()
+      .superRefine((documentType, ctx) => {
+        const hasAnyProperty =
+          !!documentType?.description ||
+          !!documentType?.catalogue.domain ||
+          !!documentType?.catalogue.rsin;
+        if (hasAnyProperty) {
+          if (!documentType.description) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: intl.formatMessage({
+                description:
+                  'File registration validation error for missing document type description',
+                defaultMessage:
+                  'You must specify a document type description when a catalogue is configured.',
+              }),
+              path: ['description'],
+            });
+          }
+          if (!documentType?.catalogue.domain) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: intl.formatMessage({
+                description:
+                  'File registration validation error for missing catalogue domain or RSIN',
+                defaultMessage: 'You must specify both domain and RSIN.',
+              }),
+              path: ['catalogue', 'domain'],
+            });
+          }
+          if (!documentType?.catalogue.rsin) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: intl.formatMessage({
+                description:
+                  'File registration validation error for missing catalogue rsin or RSIN',
+                defaultMessage: 'You must specify both domain and RSIN.',
+              }),
+              path: ['catalogue', 'rsin'],
+            });
+          } else if (!/^[0-9]{9}$/.test(documentType.catalogue.rsin)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: intl.formatMessage({
+                description: 'File registration validation error for invalid RSIN pattern',
+                defaultMessage: 'The RSIN must consist of 9 numbers.',
+              }),
+              path: ['catalogue', 'rsin'],
+            });
+          }
+        }
+      }),
+  });
+
 const buildFileSchema = (intl: IntlShape, builderContext: BuilderContextType) =>
   z.object({
     of: ofSchema.optional(),
     maxNumberOfFiles: z.union([z.null(), z.number().int().positive().optional()]),
     fileMaxSize: buildFileMaxSizeSchema(intl, builderContext).optional(),
+    registration: buildRegistrationSchema(intl).optional(),
   });
 
 const schema: EditSchema = ({intl, builderContext}) => {

--- a/src/registry/file/edit.tsx
+++ b/src/registry/file/edit.tsx
@@ -177,10 +177,18 @@ EditForm.defaultValues = {
   maxNumberOfFiles: null,
   // registration tab
   registration: {
-    informatieobjecttype: '',
     bronorganisatie: '',
     docVertrouwelijkheidaanduiding: '',
     titel: '',
+    documentType: {
+      catalogue: {
+        domain: '',
+        rsin: '',
+      },
+      description: '',
+    },
+    // deprecated
+    informatieobjecttype: '',
   },
 };
 

--- a/src/registry/file/file-validation.stories.ts
+++ b/src/registry/file/file-validation.stories.ts
@@ -208,3 +208,30 @@ export const ValidateMaxFileSizeAgainstServerValue: Story = {
     });
   },
 };
+
+export const NewDocumentTypeConfiguration: Story = {
+  name: 'validate catalogue and document type',
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('tab', {name: 'Registration'}));
+
+    const catalogueDomain = canvas.getByLabelText('Catalogus domain');
+    const catalogueRSIN = canvas.getByLabelText('Catalogus RSIN');
+    const description = canvas.getByLabelText('Document type description');
+
+    await userEvent.clear(catalogueDomain);
+    await userEvent.clear(description);
+    await userEvent.type(catalogueRSIN, '12a');
+
+    await userEvent.keyboard('[Tab]');
+    expect(await canvas.findByText('The RSIN must consist of 9 numbers.')).toBeVisible();
+    expect(await canvas.findByText('You must specify both domain and RSIN.')).toBeVisible();
+    expect(
+      await canvas.findByText(
+        'You must specify a document type description when a catalogue is configured.'
+      )
+    ).toBeVisible();
+  },
+};

--- a/src/registry/file/registration-tab.stories.ts
+++ b/src/registry/file/registration-tab.stories.ts
@@ -34,11 +34,17 @@ export default {
 
 type Story = StoryObj<typeof RegistrationTabFields>;
 
+export const DocumentTypeViaCatalogue: Story = {
+  name: 'Registration tab - document type configuration',
+};
+
 export const DocumentTypes: Story = {
   name: 'Registration tab - document types',
 
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Legacy'}));
 
     const documentTypeSelect = canvas.getByLabelText('Information object type');
     documentTypeSelect.focus();

--- a/src/registry/file/registration-tab.tsx
+++ b/src/registry/file/registration-tab.tsx
@@ -2,7 +2,7 @@ import {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useAsync} from 'react-use';
 
-import {Select, TextField} from '@/components/formio';
+import {Panel, Select, TextField} from '@/components/formio';
 import {BuilderContext, DocumentTypeOption, SelectOption} from '@/context';
 
 interface DocumentTypeOptionsGroup {
@@ -44,6 +44,9 @@ const groupDocumentTypeOptions = (options: DocumentTypeOption[]): DocumentTypeOp
   return optGroups;
 };
 
+/**
+ * @deprecated
+ */
 const DocumentTypeSelect: React.FC<{}> = () => {
   const intl = useIntl();
   const {getDocumentTypes} = useContext(BuilderContext);
@@ -72,6 +75,108 @@ const DocumentTypeSelect: React.FC<{}> = () => {
       isClearable
       options={groupDocumentTypeOptions(options || [])}
     />
+  );
+};
+
+/**
+ * 'Modern' document type configuration.
+ *
+ * @todo Would be nice if the component configuration can be validated on the backend
+ * for 11-proef on RSIN.
+ * @todo Move this configuration out of the file component and into the plugin options,
+ * as its correctness often depends on the selected case types as well, and the Catalogi
+ * API to use is important context that we don't have here.
+ */
+const DocumentTypeConfiguration: React.FC = () => {
+  const intl = useIntl();
+  return (
+    <Panel
+      title={
+        <FormattedMessage
+          description="File component registration: document type configuration"
+          defaultMessage="Document type"
+        />
+      }
+      tooltip={intl.formatMessage({
+        description: 'Tooltip file component registration: document type configuration',
+        defaultMessage: `Specify the document type to use for the file uploads when
+        sending them to the Documents API. The direct URL references are replaced with
+        references to the catalogue and document type description.`,
+      })}
+    >
+      <div className="alert alert-info">
+        <FormattedMessage
+          description="Description for 'registration.documentType' configuration"
+          defaultMessage="Specify either none or all three of the fields below to configure the document type to use."
+        />
+      </div>
+
+      <TextField
+        name="registration.documentType.catalogue.domain"
+        label={
+          <FormattedMessage
+            description="Label for 'registration.documentType.catalogue.domain' builder field"
+            defaultMessage="Catalogus domain"
+          />
+        }
+        tooltip={
+          <FormattedMessage
+            description="Tooltip for 'registration.documentType.catalogue.domain' builder field"
+            defaultMessage="The 'domein' attribute for the Catalogus resource in the Catalogi API."
+          />
+        }
+      />
+      <TextField
+        name="registration.documentType.catalogue.rsin"
+        label={
+          <FormattedMessage
+            description="Label for 'registration.documentType.catalogue.rsin' builder field"
+            defaultMessage="Catalogus RSIN"
+          />
+        }
+        tooltip={
+          <FormattedMessage
+            description="Tooltip for 'registration.documentType.catalogue.rsin' builder field"
+            defaultMessage="The 'rsin' attribute for the Catalogus resource in the Catalogi API."
+          />
+        }
+      />
+      <TextField
+        name="registration.documentType.description"
+        label={
+          <FormattedMessage
+            description="Label for 'registration.documentType.description' builder field"
+            defaultMessage="Document type description"
+          />
+        }
+        tooltip={
+          <FormattedMessage
+            description="Tooltip for 'registration.documentType.description' builder field"
+            defaultMessage={`The document type will be retrieved in the specified catalogue.
+            The version will automatically be selected based on the submission completion
+            timestamp. When used with ZGW APIs, ensure that the document type belongs to
+            the specified case type!`}
+          />
+        }
+      />
+      <Panel
+        title={
+          <FormattedMessage
+            description="File component registration: legacy configuration"
+            defaultMessage="Legacy"
+          />
+        }
+        tooltip={intl.formatMessage({
+          description: 'Tooltip file component registration: legacy document type configuration',
+          defaultMessage: `The direct URL configuration is scheduled for removal. If both
+          the URL and the fields above are configured, the new configuration is used.`,
+        })}
+        collapsible
+        initialCollapsed
+      >
+        <DocumentTypeSelect />
+      </Panel>
+    </Panel>
   );
 };
 
@@ -157,7 +262,7 @@ const Title = () => {
 const RegistrationTabFields: React.FC<{}> = () => {
   return (
     <>
-      <DocumentTypeSelect />
+      <DocumentTypeConfiguration />
       <SourceOrganisation />
       <ConfidentialityLevelSelect />
       <Title />


### PR DESCRIPTION
Closes #283 - depends on https://github.com/open-formulieren/types/pull/93

To be able to migrate and visualize the result from migration scripts, the builder must allow configuring the document type reference by catalogue identifiers and document type reference.

This is a minimal approach without much useful validation, as it needs to be applied to 3.5.x stable for people to be able to migrate in preparation for the 4.0 upgrade.