### PR TITLE
Implement content component designer preview

### DIFF
--- a/src/components/designer/Preview.stories.tsx
+++ b/src/components/designer/Preview.stories.tsx
@@ -3033,7 +3033,6 @@ export const LicensePlateMultiple: Story = {
   },
 };
 
-// @TODO implement preview component and play
 export const Content: Story = {
   name: 'Content',
   args: {
@@ -3042,15 +3041,45 @@ export const Content: Story = {
         id: 'content',
         type: 'content',
         key: 'content',
-        html: 'Custom content',
+        html: `
+          <p>Custom content</p>
+          <ul><li>List item 1</li><li>List item 2</li></ul>
+          <ol><li>List item 1</li><li>List item 2</li></ol>
+          <p><b>Bold</b> <s>or</s> and <i>italic</i> <u>content</u>, it can even contain <a href="#">links</a></p>
+`,
       } satisfies ContentComponentSchema,
       {
         id: 'contentHidden',
         type: 'content',
         key: 'contentHidden',
-        html: 'Custom content in hidden state',
+        html: `
+          <p>Custom hidden content</p>
+          <ul><li>List item 1</li><li>List item 2</li></ul>
+          <ol><li>List item 1</li><li>List item 2</li></ol>
+          <p><b>Bold</b> <s>or</s> and <i>italic</i> <u>content</u>, it can even contain <a href="#">links</a></p>
+`,
+        hidden: true,
       } satisfies ContentComponentSchema,
     ],
+  },
+  play: ({canvasElement, args}) => {
+    const canvas = within(canvasElement);
+
+    const regularContent = canvas.getByTestId('input-content');
+    const hiddenContent = canvas.getByTestId('input-contentHidden');
+    expect(regularContent).toBeVisible();
+    expect(hiddenContent).toBeVisible();
+
+    // Expect the wrapper of the hidden component to have a descriptive "is hidden" title
+    const hiddenInputWrapper = hiddenContent.closest('[data-testid="designerPreview"]');
+    expect(hiddenInputWrapper).toBeInTheDocument();
+    expect(hiddenInputWrapper).toHaveAttribute('title', 'Hidden component');
+
+    // The content of the regular content preview matches the component configuration
+    expect(regularContent).toContainHTML((args.components[0] as ContentComponentSchema).html);
+
+    // The content of the hidden content preview matches the component configuration
+    expect(hiddenContent).toContainHTML((args.components[1] as ContentComponentSchema).html);
   },
 };
 

--- a/src/registry/content/designer-preview.scss
+++ b/src/registry/content/designer-preview.scss
@@ -1,0 +1,4 @@
+.offb-designer-preview.offb-designer-preview--component-type-content {
+  padding-inline: 10px;
+  border: dashed 2px #dddddd;
+}

--- a/src/registry/content/designer-preview.tsx
+++ b/src/registry/content/designer-preview.tsx
@@ -1,0 +1,12 @@
+import {ContentComponentSchema} from '@open-formulieren/types';
+
+import {ComponentPreviewProps} from '../types';
+import './designer-preview.scss';
+
+const Preview: React.FC<ComponentPreviewProps<ContentComponentSchema>> = ({component}) => {
+  const {html, key} = component;
+
+  return <div dangerouslySetInnerHTML={{__html: html}} data-testid={`input-${key}`} />;
+};
+
+export default Preview;

--- a/src/registry/content/index.ts
+++ b/src/registry/content/index.ts
@@ -1,6 +1,7 @@
 import {ContentComponentSchema} from '@open-formulieren/types';
 
 import {RegistryEntry} from '../types';
+import DesignerPreview from './designer-preview';
 import EditForm from './edit';
 import validationSchema from './edit-validation';
 
@@ -9,7 +10,7 @@ export default {
   editSchema: validationSchema,
   preview: {
     panel: null,
-    // @TODO add designer preview
+    designer: DesignerPreview,
   },
   defaultValue: undefined, // a content component does not hold a value itself
 } satisfies RegistryEntry<ContentComponentSchema>;


### PR DESCRIPTION
Partly closes #267

Implementing the `content` component form designer preview component