### PR TITLE
Implement map designer preview

### DIFF
--- a/src/components/designer/Preview.stories.tsx
+++ b/src/components/designer/Preview.stories.tsx
@@ -3617,7 +3617,6 @@ export const Signature: Story = {
   },
 };
 
-// @TODO implement preview component and play
 export const LeafletMap: Story = {
   name: 'Map',
   args: {
@@ -3626,18 +3625,42 @@ export const LeafletMap: Story = {
         id: 'wekruya',
         type: 'map',
         key: 'map',
-        label: 'A map preview',
+        label: 'Map preview',
+        tooltip: 'An example for the tooltip',
+        description: 'A preview of the map Formio component',
+        interactions: {marker: true, polyline: true, polygon: true},
         useConfigDefaultMapSettings: true,
       },
       {
         id: 'wekruyaHidden',
         type: 'map',
         key: 'mapHidden',
-        label: 'A map preview hidden',
+        label: 'Map preview hidden',
+        tooltip: 'An example for the tooltip',
+        description: 'A preview of the map Formio component in hidden state',
+        interactions: {marker: true, polyline: true, polygon: true},
         useConfigDefaultMapSettings: true,
-        hidden: true, // must be ignored
+        hidden: true,
       },
     ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // Expect label and description to be shown
+    const inputLabel = await canvas.findByText('Map preview');
+    expect(inputLabel).toBeVisible();
+    expect(canvas.getByText('A preview of the map Formio component')).toBeVisible();
+
+    // Expect the label and description of the hidden component to be visible
+    const hiddenInputLabel = await canvas.findByText('Map preview hidden');
+    expect(hiddenInputLabel).toBeVisible();
+    expect(canvas.getByText('A preview of the map Formio component in hidden state')).toBeVisible();
+
+    // Expect the wrapper of the hidden component to have a descriptive "is hidden" title
+    const hiddenInputWrapper = hiddenInputLabel.closest('[data-testid="designerPreview"]');
+    expect(hiddenInputWrapper).toBeInTheDocument();
+    expect(hiddenInputWrapper).toHaveAttribute('title', 'Hidden component');
   },
 };
 

--- a/src/registry/map/index.ts
+++ b/src/registry/map/index.ts
@@ -12,10 +12,7 @@ import Preview from './preview';
 export default {
   edit: EditForm,
   editSchema: validationSchema,
-  // @TODO add designer preview. Current admin uses a normal preview without interactions
-  // See if we can use the existing Preview component, or if we need to add a
-  // 'without interactions' variant/prop.
-  preview: {panel: Preview},
+  preview: {panel: Preview, designer: Preview},
   formDesigner: {
     label: defineMessage({
       description: 'Map component type label',

--- a/src/registry/map/preview.tsx
+++ b/src/registry/map/preview.tsx
@@ -153,6 +153,7 @@ const Preview: React.FC<ComponentPreviewProps<MapComponentSchema>> = ({component
           display: 'flex',
           flexDirection: 'column',
           minBlockSize: '400px',
+          zIndex: 0, // Prevent the map component from covering tooltips
         }}
       >
         <TileLayer {...TILE_LAYER_RD} url={tileLayerUrl()} />


### PR DESCRIPTION
Partly closes #267

Implementing the form designer preview component for the `map` component

For now we re-use the regular map component preview component. The map interactions might interfere with the drag-n-drop behaviour, but we need the drag-n-drop to know this for sure.

If we do end up needing a custom designer preview for the map component, we can add that later.