### PR TITLE
Form designer drag-and-drop for layout components

### DIFF
--- a/src/components/designer/ComponentsList/ComponentsGroup.tsx
+++ b/src/components/designer/ComponentsList/ComponentsGroup.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import {FormattedMessage} from 'react-intl';
 
 import {DraggableMenuItem} from '@/components/designer/dragDrop';
-import type {NormalizedComponentDefinition} from '@/components/designer/types';
+import type {NormalizedComponentConfiguration} from '@/components/designer/types';
 
 import './ComponentsGroup.scss';
 
@@ -11,7 +11,7 @@ interface ComponentsGroupProps {
   isSearching?: boolean;
   isDefault?: boolean;
   title: React.ReactNode;
-  componentDefinitions: NormalizedComponentDefinition[];
+  componentConfigurations: NormalizedComponentConfiguration[];
 }
 
 /**
@@ -25,9 +25,9 @@ const ComponentsGroup: React.FC<ComponentsGroupProps> = ({
   isSearching,
   isDefault,
   title,
-  componentDefinitions,
+  componentConfigurations,
 }) => {
-  if (componentDefinitions.length === 0) return null;
+  if (componentConfigurations.length === 0) return null;
 
   return (
     <details
@@ -43,7 +43,7 @@ const ComponentsGroup: React.FC<ComponentsGroupProps> = ({
 
       <div className="card-body p-2">
         <ul className="list-unstyled mb-0">
-          {componentDefinitions.map((component, index) => (
+          {componentConfigurations.map((component, index) => (
             <li key={`${component.schema.key}-${component.schema.type}-${index}`}>
               <DraggableMenuItem type={component.schema.type}>
                 <span

--- a/src/components/designer/ComponentsList/ComponentsList.tsx
+++ b/src/components/designer/ComponentsList/ComponentsList.tsx
@@ -6,7 +6,7 @@ import type {NormalizedComponentGroups} from '@/components/designer/types';
 import ComponentsGroup from './ComponentsGroup';
 import './ComponentsList.scss';
 import {FORM_DESIGNER_GROUPS, FORM_DESIGNER_GROUP_LABELS, FORM_DESIGNER_PRESETS} from './constants';
-import {normalizeComponentDefinition} from './normalizeComponentDefinition';
+import {normalizeComponentConfiguration} from './normalizeComponentConfiguration';
 
 const ComponentsList: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -19,7 +19,7 @@ const ComponentsList: React.FC = () => {
     // Sort the groups by weight and normalize the components in each group.
     const normalizedGroups: NormalizedComponentGroups[] = FORM_DESIGNER_GROUPS.map(group => ({
       groupName: group.name,
-      components: normalizeComponentDefinition(group, intl),
+      components: normalizeComponentConfiguration(group, intl),
     }));
 
     // Add the preset group as last.
@@ -76,7 +76,7 @@ const ComponentsList: React.FC = () => {
             isDefault={index === 0}
             testId={`component-group--${groupName}`}
             title={<FormattedMessage {...FORM_DESIGNER_GROUP_LABELS[groupName]} />}
-            componentDefinitions={components}
+            componentConfigurations={components}
           />
         ))
       ) : (

--- a/src/components/designer/ComponentsList/constants.ts
+++ b/src/components/designer/ComponentsList/constants.ts
@@ -3,7 +3,7 @@ import {defineMessages} from 'react-intl';
 import type {
   ComponentGroup,
   GroupName,
-  PresetComponentDefinition,
+  PresetComponentConfiguration,
 } from '@/components/designer/types';
 
 export const FORM_DESIGNER_GROUP_LABELS = defineMessages<GroupName>({
@@ -70,7 +70,7 @@ export const FORM_DESIGNER_GROUPS: ComponentGroup[] = [
   },
 ];
 
-export const FORM_DESIGNER_PRESETS: PresetComponentDefinition[] = [
+export const FORM_DESIGNER_PRESETS: PresetComponentConfiguration[] = [
   {
     label: 'Volledige naam',
     key: 'fullName',

--- a/src/components/designer/ComponentsList/normalizeComponentConfiguration.ts
+++ b/src/components/designer/ComponentsList/normalizeComponentConfiguration.ts
@@ -1,13 +1,13 @@
 import type {IntlShape} from 'react-intl';
 
-import type {ComponentGroup, NormalizedComponentDefinition} from '@/components/designer/types';
+import type {ComponentGroup, NormalizedComponentConfiguration} from '@/components/designer/types';
 import {getRegistryEntry} from '@/registry';
 
 /**
- * Normalize the component definitions for a given component group.
+ * Normalize the component configurations for a given component group.
  */
-export const normalizeComponentDefinition = (group: ComponentGroup, intl: IntlShape) =>
-  group.components.map<NormalizedComponentDefinition>(componentType => {
+export const normalizeComponentConfiguration = (group: ComponentGroup, intl: IntlShape) =>
+  group.components.map<NormalizedComponentConfiguration>(componentType => {
     const {formDesigner, isDeprecated, builderInfo} = getRegistryEntry(componentType);
 
     return {

--- a/src/components/designer/FormioDefinitionDesigner.stories.tsx
+++ b/src/components/designer/FormioDefinitionDesigner.stories.tsx
@@ -149,12 +149,14 @@ export const AddComponentToDropzone: Story = {
 
     await dragTo(textareaDraggableItem, dropzone);
 
-    // The textarea component should be added to the dropzone
-    expect(within(dropzone).getByTestId('input-Textarea'));
-    // As the dropzone isn't empty anymore, the instructions message should be gone.
-    expect(
-      within(dropzone).queryByText('Drag a component in the form and release the mouse button.')
-    ).not.toBeInTheDocument();
+    // Wait for the component to be added, and the instructions message to be removed.
+    await waitFor(() => {
+      expect(within(dropzone).getByTestId('input-Textarea')).toBeVisible();
+
+      expect(
+        within(dropzone).queryByText('Drag a component in the form and release the mouse button.')
+      ).not.toBeInTheDocument();
+    });
   },
 };
 

--- a/src/components/designer/FormioDefinitionDesigner.stories.tsx
+++ b/src/components/designer/FormioDefinitionDesigner.stories.tsx
@@ -1,4 +1,10 @@
-import type {AnyComponentSchema, TextFieldComponentSchema} from '@open-formulieren/types';
+import type {
+  AnyComponentSchema,
+  ColumnsComponentSchema,
+  EditGridComponentSchema,
+  FieldsetComponentSchema,
+  TextFieldComponentSchema,
+} from '@open-formulieren/types';
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {useState} from 'react';
 import {expect, userEvent, waitFor, within} from 'storybook/test';
@@ -149,5 +155,81 @@ export const AddComponentToDropzone: Story = {
     expect(
       within(dropzone).queryByText('Drag a component in the form and release the mouse button.')
     ).not.toBeInTheDocument();
+  },
+};
+
+export const ComponentInColumns: Story = {
+  args: {
+    components: [
+      {
+        id: 'wekruya',
+        type: 'columns',
+        key: 'columns',
+        columns: [
+          {
+            size: 6,
+            sizeMobile: 4,
+            components: [
+              {
+                id: 'textfield',
+                type: 'textfield',
+                key: 'textfield',
+                label: 'Textfield',
+              } satisfies TextFieldComponentSchema,
+            ],
+          },
+          {
+            size: 6,
+            sizeMobile: 4,
+            components: [],
+          },
+        ],
+      } satisfies ColumnsComponentSchema,
+    ],
+  },
+};
+
+export const ComponentInFieldset: Story = {
+  args: {
+    components: [
+      {
+        id: 'fieldset',
+        key: 'fieldset',
+        type: 'fieldset',
+        label: 'Fieldset',
+        hideHeader: false,
+        components: [
+          {
+            id: 'textfield',
+            type: 'textfield',
+            key: 'textfield',
+            label: 'Textfield',
+          } satisfies TextFieldComponentSchema,
+        ],
+      } satisfies FieldsetComponentSchema,
+    ],
+  },
+};
+
+export const ComponentInEditgrid: Story = {
+  args: {
+    components: [
+      {
+        id: 'wekruya',
+        type: 'editgrid',
+        key: 'editgrid',
+        label: 'Repeating group',
+        groupLabel: 'Item',
+        disableAddingRemovingRows: false,
+        components: [
+          {
+            id: 'textfield',
+            type: 'textfield',
+            key: 'textfield',
+            label: 'Textfield',
+          } satisfies TextFieldComponentSchema,
+        ],
+      } satisfies EditGridComponentSchema,
+    ],
   },
 };

--- a/src/components/designer/FormioDefinitionDesigner.tsx
+++ b/src/components/designer/FormioDefinitionDesigner.tsx
@@ -11,11 +11,12 @@ import {useImmer} from 'use-immer';
 
 import {
   createComponent,
-  removeComponentFromDraft,
-  removePlaceholderFromDraft,
+  getDropzoneComponents,
+  removeComponent,
+  removePlaceholder,
   replacePlaceholderWithComponent,
 } from '@/components/designer/dragDrop/utils/components';
-import {getTargetIndex} from '@/components/designer/dragDrop/utils/dragTarget';
+import {getTargetDropzoneId, getTargetIndex} from '@/components/designer/dragDrop/utils/dragTarget';
 import {MAIN_DROPZONE_ID} from '@/components/designer/dragDrop/utils/dropzone';
 import {DesignerContext} from '@/context';
 import {getRegistryEntry} from '@/registry';
@@ -45,24 +46,34 @@ const FormioDefinitionDesigner: React.FC<FormioDefinitionDesignerProps> = ({
     components,
   });
 
-  const movePlaceholder = (index: number, componentType: AnyComponentSchema['type']) => {
+  const movePlaceholder = (
+    index: number,
+    dropzoneId: string,
+    componentType: AnyComponentSchema['type']
+  ) => {
     const placeholder: ComponentPlaceholder = {
       type: COMPONENT_PLACEHOLDER_TYPE,
       componentType,
     };
 
     setItems(draft => {
-      removePlaceholderFromDraft(draft);
+      removePlaceholder(draft.components);
 
-      draft.components.splice(index, 0, placeholder);
+      const dropzoneComponents = getDropzoneComponents(draft.components, dropzoneId);
+      if (dropzoneComponents === undefined) return;
+
+      dropzoneComponents.splice(index, 0, placeholder);
     });
   };
 
-  const moveComponent = (index: number, component: AnyComponentSchema) => {
+  const moveComponent = (index: number, dropzoneId: string, component: AnyComponentSchema) => {
     setItems(draft => {
-      removeComponentFromDraft(draft, component.key);
+      removeComponent(draft.components, component.key);
 
-      draft.components.splice(index, 0, component);
+      const dropzoneComponents = getDropzoneComponents(draft.components, dropzoneId);
+      if (dropzoneComponents === undefined) return;
+
+      dropzoneComponents.splice(index, 0, component);
     });
   };
 
@@ -74,28 +85,37 @@ const FormioDefinitionDesigner: React.FC<FormioDefinitionDesignerProps> = ({
     // When moving the placeholder outside the dropzone, remove it.
     if (!target && isNewComponent) {
       setItems(draft => {
-        removePlaceholderFromDraft(draft);
+        removePlaceholder(draft.components);
       });
       return;
     }
 
-    const targetIndex = getTargetIndex(target, items.components.length);
+    const dropzoneId = getTargetDropzoneId(target);
+    if (!dropzoneId) return;
+
+    const dropzoneComponents = getDropzoneComponents(items.components, dropzoneId);
+    if (dropzoneComponents === undefined) return;
+
+    const targetIndex = getTargetIndex(target, dropzoneComponents.length);
     if (targetIndex === undefined) return;
 
     if (isNewComponent) {
-      movePlaceholder(targetIndex, sourceData.componentType);
+      movePlaceholder(targetIndex, dropzoneId, sourceData.componentType);
     } else if (sourceData?.component) {
-      moveComponent(targetIndex, sourceData.component);
+      moveComponent(targetIndex, dropzoneId, sourceData.component);
     }
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
-    const {source} = event.operation;
+    const {source, target} = event.operation;
     const sourceData = getData(source);
     const isNewComponent: boolean = sourceData?.fromSidebar;
 
     // For existing components we don't need any additional actions.
     if (!isNewComponent) return;
+
+    // If there is no target, it means the drag ended outside the dropzone.
+    if (!target) return;
 
     const newComponent = createComponent(sourceData.componentType, componentNamespace, intl);
     setItems(draft => {

--- a/src/components/designer/FormioDefinitionDesigner.tsx
+++ b/src/components/designer/FormioDefinitionDesigner.tsx
@@ -24,7 +24,7 @@ import {getRegistryEntry} from '@/registry';
 import ComponentsList from './ComponentsList';
 import ComponentsPreview, {ComponentPreview} from './Preview';
 import type {DraggableMenuItemData, SortableItemData} from './dragDrop';
-import type {ComponentPlaceholder} from './types';
+import type {ComponentDefinition, ComponentPlaceholder} from './types';
 import {COMPONENT_PLACEHOLDER_TYPE} from './types';
 
 const getData = (
@@ -42,7 +42,7 @@ const FormioDefinitionDesigner: React.FC<FormioDefinitionDesignerProps> = ({
 }) => {
   const {componentNamespace} = useContext(DesignerContext);
   const intl = useIntl();
-  const [items, setItems] = useImmer<{components: (AnyComponentSchema | ComponentPlaceholder)[]}>({
+  const [items, setItems] = useImmer<{components: ComponentDefinition[]}>({
     components,
   });
 

--- a/src/components/designer/Preview.stories.tsx
+++ b/src/components/designer/Preview.stories.tsx
@@ -43,6 +43,9 @@ export default {
   parameters: {
     modal: {noModal: true},
   },
+  args: {
+    dropzoneId: 'dropzone',
+  },
 } as Meta<typeof Preview>;
 
 type Story = StoryObj<typeof Preview>;
@@ -651,7 +654,6 @@ export const NumberField: Story = {
   },
 };
 
-// @TODO replace preview component with variant without input prefix and update test
 export const CurrencyField: Story = {
   args: {
     components: [

--- a/src/components/designer/Preview.tsx
+++ b/src/components/designer/Preview.tsx
@@ -11,11 +11,11 @@ import {hasOwnProperty} from '@/types';
 import './Preview.scss';
 import {DropZone, SortableComponent} from './dragDrop';
 import {getTargetDropzoneId} from './dragDrop/utils/dragTarget';
-import type {ComponentPlaceholder} from './types';
+import type {ComponentDefinition} from './types';
 import {COMPONENT_PLACEHOLDER_TYPE} from './types';
 
 export interface ComponentsPreviewProps {
-  components: (AnyComponentSchema | ComponentPlaceholder)[];
+  components: ComponentDefinition[];
   dropzoneId: string;
   hideEmptyMessage?: boolean;
 }

--- a/src/components/designer/Preview.tsx
+++ b/src/components/designer/Preview.tsx
@@ -1,3 +1,4 @@
+import {useDragOperation} from '@dnd-kit/react';
 import type {AnyComponentSchema} from '@open-formulieren/types';
 import clsx from 'clsx';
 import {FormattedMessage, useIntl} from 'react-intl';
@@ -9,6 +10,7 @@ import {hasOwnProperty} from '@/types';
 
 import './Preview.scss';
 import {DropZone, SortableComponent} from './dragDrop';
+import {getTargetDropzoneId} from './dragDrop/utils/dragTarget';
 import type {ComponentPlaceholder} from './types';
 import {COMPONENT_PLACEHOLDER_TYPE} from './types';
 
@@ -23,8 +25,13 @@ export const ComponentsPreview: React.FC<ComponentsPreviewProps> = ({
   dropzoneId,
   hideEmptyMessage = false,
 }) => {
-  const hasComponents =
-    components.filter(component => component.type !== COMPONENT_PLACEHOLDER_TYPE).length > 0;
+  const {target} = useDragOperation();
+  const targetDropzone = getTargetDropzoneId(target);
+
+  const isDraggingAboveDropzone = targetDropzone !== undefined && targetDropzone === dropzoneId;
+  // Count the number of components in the dropzone, excluding dragged components.
+  const componentCountThreshold = isDraggingAboveDropzone ? 1 : 0;
+  const hasComponents = components.length > componentCountThreshold;
 
   return (
     <ErrorBoundary>

--- a/src/components/designer/Preview.tsx
+++ b/src/components/designer/Preview.tsx
@@ -109,8 +109,7 @@ export const ComponentPreview: React.FC<ComponentPreviewProps> = ({component}) =
   const {
     preview: {designer: PreviewComponent},
   } = entry;
-  // @TODO Remove the undefined check when all components have a designer preview.
-  if (PreviewComponent === undefined || PreviewComponent === null) {
+  if (PreviewComponent === null) {
     console.info(`No designer preview found for component ${component.type}.`);
     return null;
   }

--- a/src/components/designer/dragDrop/DropZone.scss
+++ b/src/components/designer/dragDrop/DropZone.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  padding-block-end: 32px;
 
   &:hover {
     border-color: #ccc;
@@ -16,7 +17,8 @@
   }
 
   .offb-drop-zone {
-    padding: 10px;
+    padding-block-start: 10px;
+    padding-inline: 10px;
     border: dotted 2px #e8e8e8;
   }
 }

--- a/src/components/designer/dragDrop/DropZone.tsx
+++ b/src/components/designer/dragDrop/DropZone.tsx
@@ -1,6 +1,7 @@
 import {useDroppable} from '@dnd-kit/react';
 
 import './DropZone.scss';
+import {DropzoneContext, useDropzoneContext} from './context';
 
 export interface DropZoneProps {
   id: string;
@@ -11,11 +12,14 @@ export interface DropZoneProps {
  * A drag-and-drop container for components.
  */
 const DropZone: React.FC<DropZoneProps> = ({id, children}) => {
-  const {ref} = useDroppable({id});
+  const {collisionPriority} = useDropzoneContext();
+  const {ref} = useDroppable({id, collisionPriority});
 
   return (
     <div className="offb-drop-zone" data-testid={id} ref={ref}>
-      {children}
+      <DropzoneContext.Provider value={{collisionPriority: collisionPriority + 1}}>
+        {children}
+      </DropzoneContext.Provider>
     </div>
   );
 };

--- a/src/components/designer/dragDrop/SortableComponent.tsx
+++ b/src/components/designer/dragDrop/SortableComponent.tsx
@@ -2,6 +2,8 @@ import type {Data} from '@dnd-kit/abstract';
 import {useSortable} from '@dnd-kit/react/sortable';
 import type {AnyComponentSchema} from '@open-formulieren/types';
 
+import {useDropzoneContext} from './context';
+
 export interface SortableItemData extends Data {
   component: AnyComponentSchema;
 }
@@ -14,10 +16,12 @@ interface SortableItemProps extends React.PropsWithChildren {
 }
 
 const SortableItem: React.FC<SortableItemProps> = ({id, index, groupName, component, children}) => {
+  const {collisionPriority} = useDropzoneContext();
   const {ref} = useSortable<SortableItemData>({
     id,
     index,
     group: groupName,
+    collisionPriority,
     data: {
       component,
     },

--- a/src/components/designer/dragDrop/context.ts
+++ b/src/components/designer/dragDrop/context.ts
@@ -1,0 +1,11 @@
+import {createContext, useContext} from 'react';
+
+interface DropzoneContextType {
+  collisionPriority: number;
+}
+
+export const DropzoneContext = createContext<DropzoneContextType>({
+  collisionPriority: 0,
+});
+
+export const useDropzoneContext = () => useContext(DropzoneContext);

--- a/src/components/designer/dragDrop/utils/components.ts
+++ b/src/components/designer/dragDrop/utils/components.ts
@@ -1,23 +1,44 @@
 import type {AnyComponentSchema} from '@open-formulieren/types';
-import type {Draft} from 'immer';
-import {IntlShape} from 'react-intl';
+import type {IntlShape} from 'react-intl';
 
+import {
+  MAIN_DROPZONE_ID,
+  getComponentKeyFromDropzoneId,
+} from '@/components/designer/dragDrop/utils/dropzone';
 import type {ComponentPlaceholder} from '@/components/designer/types';
 import {COMPONENT_PLACEHOLDER_TYPE} from '@/components/designer/types';
 import {getRegistryEntry} from '@/registry';
 import {hasOwnProperty} from '@/types';
 
 type ComponentDefinition = AnyComponentSchema | ComponentPlaceholder;
-type DraftComponentDefinitions = Draft<{components: ComponentDefinition[]}>;
+
+const hasNestedChildren = (
+  children: AnyComponentSchema[] | AnyComponentSchema[][]
+): children is AnyComponentSchema[][] => children.length > 0 && Array.isArray(children[0]);
+
+interface IterComponentsResult {
+  /**
+   * The index of the current item.
+   */
+  index: number;
+  /**
+   * The current item.
+   */
+  component: ComponentDefinition;
+  /**
+   * The collection of items that the current item belongs to.
+   */
+  collection: ComponentDefinition[];
+}
 
 /**
  * Recursively (and depth-first) iterate over all components in the component definition.
  */
 function* iterComponents(
   componentDefinitions: ComponentDefinition[]
-): Generator<ComponentDefinition> {
-  for (const component of componentDefinitions) {
-    yield component;
+): Generator<IterComponentsResult> {
+  for (const [index, component] of componentDefinitions.entries()) {
+    yield {index, component, collection: componentDefinitions};
     if (component.type === COMPONENT_PLACEHOLDER_TYPE) continue;
 
     const {getChildComponents} = getRegistryEntry(component.type);
@@ -25,12 +46,65 @@ function* iterComponents(
     const children = getChildComponents ? getChildComponents(component) : [];
     if (!children.length) continue;
 
-    yield* iterComponents(children);
+    if (hasNestedChildren(children)) {
+      for (const child of children) {
+        yield* iterComponents(child);
+      }
+    } else {
+      yield* iterComponents(children);
+    }
   }
 }
 
 /**
- * Recursively find all component keys that start with the given string.
+ * Get the components for a given dropzone.
+ */
+export const getDropzoneComponents = (
+  components: ComponentDefinition[],
+  dropzoneId: string
+): ComponentDefinition[] | undefined => {
+  if (dropzoneId === MAIN_DROPZONE_ID) {
+    return components;
+  }
+
+  const parentKey = getComponentKeyFromDropzoneId(dropzoneId);
+  return findDropzoneComponentsByParentReference(components, parentKey);
+};
+
+/**
+ * Search for a layout component that belongs to the given reference and return its
+ * children components.
+ */
+const findDropzoneComponentsByParentReference = (
+  componentDefinitions: ComponentDefinition[],
+  key: string
+): ComponentDefinition[] | undefined => {
+  for (const {component} of iterComponents(componentDefinitions)) {
+    if (component.type === COMPONENT_PLACEHOLDER_TYPE) continue;
+
+    // Without the getChildComponents method, we cannot retrieve the component children.
+    const {getChildComponents} = getRegistryEntry(component.type);
+    if (!getChildComponents) continue;
+
+    const children = getChildComponents(component);
+
+    // If the children are an array of arrays, we are dealing with a columns component.
+    // The column index is part of the dropzone key, so we have to find the correct
+    // column.
+    if (hasNestedChildren(children)) {
+      for (const [index, child] of children.entries()) {
+        if (`${component.key}.${index}` === key) return child;
+      }
+    } else if (component.key === key) {
+      return children;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Find all component keys that start with the given string.
  */
 const findComponentKeysStartingWith = (
   startsWith: string,
@@ -38,7 +112,7 @@ const findComponentKeysStartingWith = (
 ): string[] => {
   const similarKeys: string[] = [];
 
-  for (const component of iterComponents(componentNamespace)) {
+  for (const {component} of iterComponents(componentNamespace)) {
     if (component.type !== COMPONENT_PLACEHOLDER_TYPE && component.key.startsWith(startsWith)) {
       similarKeys.push(component.key);
     }
@@ -107,74 +181,43 @@ export const createComponent = <S extends AnyComponentSchema>(
 };
 
 /**
- * Recursively remove the placeholder from the components.
+ * Remove the placeholder from the components.
  */
-const removePlaceholderFromComponents = (componentDefinitions: ComponentDefinition[]) => {
-  const index = componentDefinitions.findIndex(
-    component => component.type === COMPONENT_PLACEHOLDER_TYPE
-  );
-
-  // If the placeholder is found, remove it.
-  if (index >= 0) {
-    componentDefinitions.splice(index, 1);
-    return;
+export const removePlaceholder = (components: ComponentDefinition[]) => {
+  for (const {index, component, collection} of iterComponents(components)) {
+    if (component.type === COMPONENT_PLACEHOLDER_TYPE) {
+      collection.splice(index, 1);
+      return;
+    }
   }
-
-  // Implement recursive search into nested dropzones
 };
 
 /**
- * Remove the placeholder from the draft.
+ * Remove a component from the components collection, using the component key as an
+ * identifier.
  */
-export const removePlaceholderFromDraft = (draft: DraftComponentDefinitions) => {
-  removePlaceholderFromComponents(draft.components);
-};
-
-/**
- * Recursively remove a component from the componentDefinitions, using the component key
- * as an identifier.
- */
-const removeComponentFromComponents = (
-  componentDefinitions: ComponentDefinition[],
-  key: string
-) => {
-  const index = componentDefinitions.findIndex(
-    component => component.type !== COMPONENT_PLACEHOLDER_TYPE && component.key === key
-  );
-
-  // If the placeholder is found, remove it.
-  if (index >= 0) {
-    componentDefinitions.splice(index, 1);
-    return;
+export const removeComponent = (components: ComponentDefinition[], componentKey: string) => {
+  for (const {index, component, collection} of iterComponents(components)) {
+    if (component.type !== COMPONENT_PLACEHOLDER_TYPE && component.key === componentKey) {
+      collection.splice(index, 1);
+      return;
+    }
   }
-
-  // Implement recursive search into nested dropzones
 };
 
 /**
- * Remove a component from the draft, using the component key as an identifier, and
- * return the removed component.
- */
-export const removeComponentFromDraft = (draft: DraftComponentDefinitions, key: string) => {
-  removeComponentFromComponents(draft.components, key);
-};
-
-/**
- * Recursively search for the placeholder in the components and replace it with the given
- * component.
+ * Search for the placeholder in the components and replace it with the given component.
  */
 export const replacePlaceholderWithComponent = (
   componentDefinitions: ComponentDefinition[],
   component: AnyComponentSchema
 ) => {
-  const index = componentDefinitions.findIndex(
-    componentDefinition => componentDefinition.type === COMPONENT_PLACEHOLDER_TYPE
-  );
-
-  if (index >= 0) {
-    componentDefinitions[index] = component;
-    return;
+  for (const {index, component: componentDefinition, collection} of iterComponents(
+    componentDefinitions
+  )) {
+    if (componentDefinition.type === COMPONENT_PLACEHOLDER_TYPE) {
+      collection[index] = component;
+      return;
+    }
   }
-
-  // Implement recursive search into nested dropzones
 };

--- a/src/components/designer/dragDrop/utils/components.ts
+++ b/src/components/designer/dragDrop/utils/components.ts
@@ -5,12 +5,10 @@ import {
   MAIN_DROPZONE_ID,
   getComponentKeyFromDropzoneId,
 } from '@/components/designer/dragDrop/utils/dropzone';
-import type {ComponentPlaceholder} from '@/components/designer/types';
+import type {ComponentDefinition} from '@/components/designer/types';
 import {COMPONENT_PLACEHOLDER_TYPE} from '@/components/designer/types';
 import {getRegistryEntry} from '@/registry';
 import {hasOwnProperty} from '@/types';
-
-type ComponentDefinition = AnyComponentSchema | ComponentPlaceholder;
 
 interface IterComponentsResult {
   /**

--- a/src/components/designer/dragDrop/utils/components.ts
+++ b/src/components/designer/dragDrop/utils/components.ts
@@ -12,10 +12,6 @@ import {hasOwnProperty} from '@/types';
 
 type ComponentDefinition = AnyComponentSchema | ComponentPlaceholder;
 
-const hasNestedChildren = (
-  children: AnyComponentSchema[] | AnyComponentSchema[][]
-): children is AnyComponentSchema[][] => children.length > 0 && Array.isArray(children[0]);
-
 interface IterComponentsResult {
   /**
    * The index of the current item.
@@ -41,17 +37,11 @@ function* iterComponents(
     yield {index, component, collection: componentDefinitions};
     if (component.type === COMPONENT_PLACEHOLDER_TYPE) continue;
 
-    const {getChildComponents} = getRegistryEntry(component.type);
+    const {getComponentSlots} = getRegistryEntry(component.type);
+    if (!getComponentSlots) continue;
 
-    const children = getChildComponents ? getChildComponents(component) : [];
-    if (!children.length) continue;
-
-    if (hasNestedChildren(children)) {
-      for (const child of children) {
-        yield* iterComponents(child);
-      }
-    } else {
-      yield* iterComponents(children);
+    for (const slot of getComponentSlots(component)) {
+      yield* iterComponents(slot.collection);
     }
   }
 }
@@ -77,26 +67,16 @@ export const getDropzoneComponents = (
  */
 const findDropzoneComponentsByParentReference = (
   componentDefinitions: ComponentDefinition[],
-  key: string
+  parentReference: string
 ): ComponentDefinition[] | undefined => {
   for (const {component} of iterComponents(componentDefinitions)) {
     if (component.type === COMPONENT_PLACEHOLDER_TYPE) continue;
 
-    // Without the getChildComponents method, we cannot retrieve the component children.
-    const {getChildComponents} = getRegistryEntry(component.type);
-    if (!getChildComponents) continue;
+    const {getComponentSlots} = getRegistryEntry(component.type);
+    if (!getComponentSlots) continue;
 
-    const children = getChildComponents(component);
-
-    // If the children are an array of arrays, we are dealing with a columns component.
-    // The column index is part of the dropzone key, so we have to find the correct
-    // column.
-    if (hasNestedChildren(children)) {
-      for (const [index, child] of children.entries()) {
-        if (`${component.key}.${index}` === key) return child;
-      }
-    } else if (component.key === key) {
-      return children;
+    for (const slot of getComponentSlots(component)) {
+      if (slot.reference === parentReference) return slot.collection;
     }
   }
 

--- a/src/components/designer/dragDrop/utils/dragTarget.ts
+++ b/src/components/designer/dragDrop/utils/dragTarget.ts
@@ -3,6 +3,21 @@ import {isSortable} from '@dnd-kit/react/sortable';
 
 import {isDropzoneId} from './dropzone';
 
+export const getTargetDropzoneId = (target: Droppable | null | undefined): string | undefined => {
+  if (!target) return undefined;
+
+  if (isSortable(target)) {
+    return String(target.group);
+  }
+
+  const id = String(target.id);
+  if (isDropzoneId(id)) {
+    return id;
+  }
+
+  return undefined;
+};
+
 export const getTargetIndex = (
   target: Droppable | null,
   dropzoneFieldsLength: number

--- a/src/components/designer/types.ts
+++ b/src/components/designer/types.ts
@@ -3,6 +3,12 @@ import type {AnyComponentSchema} from '@open-formulieren/types';
 export const COMPONENT_PLACEHOLDER_TYPE = 'componentPlaceholder';
 
 /**
+ * The component definition that is used in the FormDesigner. This can be a component
+ * schema, or a placeholder for a new component.
+ */
+export type ComponentDefinition = AnyComponentSchema | ComponentPlaceholder;
+
+/**
  * A temporary component placeholder used when adding a new component to a FormDesigner
  * dropzone.
  */
@@ -14,7 +20,7 @@ export interface ComponentPlaceholder {
 /**
  * Configuration for a custom preset component.
  */
-export type PresetComponentDefinition = {
+export type PresetComponentConfiguration = {
   key: string;
   label: string;
   icon: string;
@@ -22,11 +28,12 @@ export type PresetComponentDefinition = {
 };
 
 /**
- * A normalized component definition, containing UI information and the component schema.
+ * A normalized component configuration, containing UI information and the component
+ * schema.
  *
  * This is used to render the component in the designer.
  */
-export type NormalizedComponentDefinition = {
+export type NormalizedComponentConfiguration = {
   key: string;
   label: string;
   icon: string;
@@ -37,17 +44,18 @@ export type NormalizedComponentDefinition = {
 /**
  * A normalized component group, containing the group name and the components in that group.
  *
- * Because we support multiple group sources, backend defined and custom preset groups,
+ * Because we support multiple group sources, backend-defined and custom preset groups,
  * we need to normalize the groups to a common format.
  *
- * For the backend defined `ComponentGroup`, we fetch the component definitions from the
- * backend project.
+ * For the backend-defined components, we use a statically defined collection of
+ * component definitions.
  *
- * For the custom preset groups, we simply use the `PresetComponentDefinition` objects.
+ * For the custom preset groups, we simply use the `PresetComponentConfiguration`
+ * objects.
  */
 export type NormalizedComponentGroups = {
   groupName: GroupName;
-  components: NormalizedComponentDefinition[];
+  components: NormalizedComponentConfiguration[];
 };
 
 /**

--- a/src/registry/columns/index.ts
+++ b/src/registry/columns/index.ts
@@ -32,5 +32,5 @@ export default {
     },
   },
   defaultValue: undefined, // a column component does not hold a value itself
-  getChildComponents: component => component.columns.map(column => column.components).flat(1),
+  getChildComponents: component => component.columns.map(column => column.components),
 } satisfies RegistryEntry<ColumnsComponentSchema>;

--- a/src/registry/columns/index.ts
+++ b/src/registry/columns/index.ts
@@ -32,5 +32,9 @@ export default {
     },
   },
   defaultValue: undefined, // a column component does not hold a value itself
-  getChildComponents: component => component.columns.map(column => column.components),
+  getComponentSlots: component =>
+    component.columns.map((column, index) => ({
+      reference: `${component.key}.${index}`,
+      collection: column.components,
+    })),
 } satisfies RegistryEntry<ColumnsComponentSchema>;

--- a/src/registry/editgrid/index.ts
+++ b/src/registry/editgrid/index.ts
@@ -31,5 +31,10 @@ export default {
     },
   },
   defaultValue: [],
-  getChildComponents: component => component.components,
+  getComponentSlots: component => [
+    {
+      reference: component.key,
+      collection: component.components,
+    },
+  ],
 } satisfies RegistryEntry<EditGridComponentSchema>;

--- a/src/registry/fieldset/index.ts
+++ b/src/registry/fieldset/index.ts
@@ -31,5 +31,10 @@ export default {
     },
   },
   defaultValue: undefined, // a fieldset component does not hold a value itself
-  getChildComponents: component => component.components,
+  getComponentSlots: component => [
+    {
+      reference: component.key,
+      collection: component.components,
+    },
+  ],
 } satisfies RegistryEntry<FieldsetComponentSchema>;

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -76,6 +76,19 @@ export interface BuilderInfo<S extends AnyComponentSchema> {
 
 type DefaultValueOf<S> = S extends {defaultValue?: infer D} ? D : never;
 
+export interface ComponentSlot {
+  /**
+   * Reference to the collection the components belong to.
+   *
+   * Example: for the columns component this is '[parent component key].[column index]'
+   */
+  reference: string;
+  /**
+   * The components in this slot.
+   */
+  collection: AnyComponentSchema[];
+}
+
 export interface RegistryEntry<S extends AnyComponentSchema> {
   edit: EditFormDefinition<S>;
   editSchema: EditSchema;
@@ -88,9 +101,9 @@ export interface RegistryEntry<S extends AnyComponentSchema> {
   defaultValue: DefaultValueOf<S> | JSONValue | undefined;
   comparisonValue?: React.FC<ComparisonValueProps>;
   // All components that can have children should implement this method.
-  // The children should be returned as a one-level array, unless the nested structure is
-  // significant for the component (like in the case of a columns component).
-  getChildComponents?: (component: S) => AnyComponentSchema[] | AnyComponentSchema[][];
+  // It returns an array of component slots, with references to where those slots are
+  // located in the form builder structure.
+  getComponentSlots?: (component: S) => ComponentSlot[];
 }
 
 // Registry made up of registry entries, one for each possible component schema

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -87,7 +87,10 @@ export interface RegistryEntry<S extends AnyComponentSchema> {
   // initial data
   defaultValue: DefaultValueOf<S> | JSONValue | undefined;
   comparisonValue?: React.FC<ComparisonValueProps>;
-  getChildComponents?: (component: S) => AnyComponentSchema[];
+  // All components that can have children should implement this method.
+  // The children should be returned as a one-level array, unless the nested structure is
+  // significant for the component (like in the case of a columns component).
+  getChildComponents?: (component: S) => AnyComponentSchema[] | AnyComponentSchema[][];
 }
 
 // Registry made up of registry entries, one for each possible component schema

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -52,10 +52,8 @@ export interface Previews {
    *
    * The preview updates as the component configuration itself is modified through form
    * field interaction and is saved.
-   *
-   * @TODO make this required once all components have a preview component assigned.
    */
-  designer?: React.FC<ComponentPreviewProps> | null;
+  designer: React.FC<ComponentPreviewProps> | null;
 }
 
 export interface FormDesigner {


### PR DESCRIPTION
Closes #269

Extending the form designer drag-and-drop behavior by supporting multiple nested dropzones (i.e. layout components like editgrid, fieldset and columns).

Interaction testing seems rather flaky (related to #296, I think), so to prevent future headaches with having to re-run failing tests, I've opted to keep the storybook tests simple for now.