### PR TITLE
Always grab the builder info from the registry

### DIFF
--- a/src/components/ComponentConfiguration.stories.tsx
+++ b/src/components/ComponentConfiguration.stories.tsx
@@ -12,7 +12,6 @@ import {select} from 'react-select-event';
 import {expect, fireEvent, fn, userEvent, waitFor, within} from 'storybook/test';
 
 import type {FormType} from '@/context';
-import type {BuilderInfo} from '@/registry/types';
 import {
   DEFAULT_AUTH_PLUGINS,
   DEFAULT_COLORS,
@@ -92,18 +91,6 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-    builderInfo: {
-      title: 'Text field',
-      group: 'basic',
-      icon: 'terminal',
-      schema: {
-        id: 'textfield',
-        key: 'textfield',
-        type: 'textfield',
-        label: 'A text field',
-      },
-      weight: 0,
-    },
   },
 } as Meta<typeof ComponentConfiguration>;
 
@@ -120,7 +107,6 @@ interface TemplateArgs {
   prefillAttributes: Record<string, PrefillAttributeOption[]>;
   fileTypes: Array<{value: string; label: string}>;
   isNew: boolean;
-  builderInfo: BuilderInfo<AnyComponentSchema>;
   formType: FormType;
   onCancel: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onRemove: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -140,7 +126,6 @@ const Template: StoryFn<TemplateArgs> = ({
   referenceListsTableItems,
   fileTypes,
   isNew,
-  builderInfo,
   formType,
   onCancel,
   onRemove,
@@ -166,7 +151,6 @@ const Template: StoryFn<TemplateArgs> = ({
     getAuthPlugins={async () => DEFAULT_AUTH_PLUGINS}
     component={component}
     isNew={isNew}
-    builderInfo={builderInfo}
     formType={formType}
     onCancel={onCancel}
     onRemove={onRemove}
@@ -201,16 +185,6 @@ export const UnsupportedComponent: Story = {
     component: {
       // @ts-expect-error unsupported type value
       type: 'an-invalid-type',
-    },
-    builderInfo: {
-      title: 'invalid',
-      group: 'basic',
-      icon: 'terminal',
-      schema: {
-        // @ts-expect-error unsupported type value
-        type: 'an-invalid-type',
-      },
-      weight: 0,
     },
   },
 };
@@ -294,21 +268,6 @@ export const Email: Story = {
       validate: {
         required: false,
       },
-    },
-    builderInfo: {
-      title: 'Email',
-      group: 'basic',
-      icon: 'at',
-      schema: {
-        id: 'ikrnvhe',
-        type: 'email',
-        key: 'email',
-        label: 'An email field',
-        validate: {
-          required: false,
-        },
-      },
-      weight: 10,
     },
   },
 
@@ -402,22 +361,6 @@ export const NumberField: Story = {
         },
       },
     ],
-
-    builderInfo: {
-      title: 'Number',
-      group: 'basic',
-      icon: 'hashtag',
-      schema: {
-        id: 'wekruya',
-        type: 'number',
-        key: 'number',
-        label: 'A number field',
-        validate: {
-          required: false,
-        },
-      },
-      weight: 30,
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -535,24 +478,6 @@ export const Textarea: Story = {
         required: false,
       },
     },
-
-    builderInfo: {
-      title: 'Textarea',
-      group: 'basic',
-      icon: 'hashtag',
-      schema: {
-        id: 'wekruya',
-        type: 'textarea',
-        key: 'textarea',
-        label: 'A textarea field',
-        autoExpand: false,
-        rows: 3,
-        validate: {
-          required: false,
-        },
-      },
-      weight: 30,
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -616,22 +541,6 @@ export const DateField: Story = {
       label: 'A date field',
       validate: {
         required: false,
-      },
-    },
-
-    builderInfo: {
-      title: 'Date Field',
-      icon: 'calendar',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'date',
-        key: 'date',
-        label: 'A date field',
-        validate: {
-          required: false,
-        },
       },
     },
   },
@@ -708,22 +617,6 @@ export const DateTimeField: Story = {
         required: false,
       },
     },
-
-    builderInfo: {
-      title: 'Date/Time Field',
-      icon: 'calendar-plus',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'datetime',
-        key: 'datetime',
-        label: 'A datetime field',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -795,22 +688,6 @@ export const TimeField: Story = {
       label: 'A time field',
       validate: {
         required: false,
-      },
-    },
-
-    builderInfo: {
-      title: 'Time Field',
-      icon: 'clock-o',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'time',
-        key: 'time',
-        label: 'A time field',
-        validate: {
-          required: false,
-        },
       },
     },
   },
@@ -887,23 +764,6 @@ export const Postcode: Story = {
         pattern: '^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$',
       },
     },
-
-    builderInfo: {
-      title: 'Postcode',
-      icon: 'home',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'postcode',
-        key: 'postcode',
-        label: 'A postcode field',
-        validate: {
-          required: false,
-          pattern: '^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$',
-        },
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -973,19 +833,6 @@ export const PhoneNumber: Story = {
       key: 'phoneNumber',
       label: 'A phone number field',
     },
-
-    builderInfo: {
-      title: 'Phone number',
-      icon: 'phone-square',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'phoneNumber',
-        key: 'phoneNumber',
-        label: 'A phone number field',
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -1054,25 +901,6 @@ export const FileUpload: Story = {
         allowedTypesLabels: [],
       },
       filePattern: '',
-    },
-
-    builderInfo: {
-      title: 'File upload',
-      icon: '',
-      group: 'file',
-      weight: 10,
-      schema: {
-        id: 'kiweljhr',
-        type: 'file',
-        key: 'file',
-        label: 'A file upload',
-        file: {
-          name: '',
-          type: [],
-          allowedTypesLabels: [],
-        },
-        filePattern: '',
-      },
     },
   },
 
@@ -1196,25 +1024,6 @@ export const SelectBoxes: Story = {
       },
       values: [],
       defaultValue: {},
-    },
-
-    builderInfo: {
-      title: 'Select Boxes',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'selectboxes',
-        key: 'selectboxes',
-        label: 'A selectboxes field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [],
-        defaultValue: {},
-      },
     },
   },
 
@@ -1439,25 +1248,6 @@ export const Radio: Story = {
       values: [],
       defaultValue: '',
     },
-
-    builderInfo: {
-      title: 'Radio',
-      icon: 'dot-circle-o',
-      group: 'basic',
-      weight: 100,
-      schema: {
-        id: 'wqimsadk',
-        type: 'radio',
-        key: 'radio',
-        label: 'A radio field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [],
-        defaultValue: '',
-      },
-    },
   },
 
   play: async ({canvasElement, step, args}) => {
@@ -1670,25 +1460,6 @@ export const Select: Story = {
       data: {values: []},
       defaultValue: '',
     } satisfies SelectComponentSchema,
-
-    builderInfo: {
-      title: 'Select',
-      icon: 'th-list',
-      group: 'basic',
-      weight: 70,
-      schema: {
-        id: 'wqimsadk',
-        type: 'select',
-        key: 'select',
-        label: 'A select field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        data: {values: []},
-        defaultValue: '',
-      },
-    },
   },
 
   play: async ({canvasElement, step, args}) => {
@@ -1923,22 +1694,6 @@ export const BSN: Story = {
         required: false,
       },
     },
-
-    builderInfo: {
-      title: 'BSN Field',
-      icon: 'id-card-o',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'bsn',
-        key: 'bsn',
-        label: 'A BSN field',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -2024,23 +1779,6 @@ export const Checkbox: Story = {
         defaultValue: false,
       },
     ],
-
-    builderInfo: {
-      title: 'Checkbox',
-      icon: 'check-square',
-      group: 'basic',
-      weight: 50,
-      schema: {
-        id: 'wekruya',
-        type: 'checkbox',
-        key: 'checkbox',
-        label: 'A checkbox field',
-        validate: {
-          required: false,
-        },
-        defaultValue: false,
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -2157,23 +1895,6 @@ export const Currency: Story = {
         },
       },
     ],
-
-    builderInfo: {
-      title: 'Currency',
-      icon: 'eur',
-      group: 'basic',
-      weight: 70,
-      schema: {
-        id: 'wekruya',
-        type: 'currency',
-        currency: 'EUR',
-        key: 'currency',
-        label: 'A currency field',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -2239,22 +1960,6 @@ export const Iban: Story = {
       label: 'An IBAN field',
       validate: {
         required: false,
-      },
-    },
-
-    builderInfo: {
-      title: 'IBAN Field',
-      icon: 'wallet',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'iban',
-        key: 'iban',
-        label: 'An IBAN field',
-        validate: {
-          required: false,
-        },
       },
     },
   },
@@ -2329,23 +2034,6 @@ export const LicensePlate: Story = {
         pattern: '^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$',
       },
     },
-
-    builderInfo: {
-      title: 'licenseplate Field',
-      icon: 'wallet',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'licenseplate',
-        key: 'licenseplate',
-        label: 'A license plate field',
-        validate: {
-          required: false,
-          pattern: '^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$',
-        },
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -2415,21 +2103,6 @@ export const NpFamilyMembers: Story = {
       label: 'An npFamilyMembers field',
       includeChildren: true,
       includePartners: false,
-    },
-
-    builderInfo: {
-      title: 'Family members',
-      icon: 'users',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wqimsadk',
-        type: 'npFamilyMembers',
-        key: 'npFamilyMembers',
-        label: 'An npFamilyMembers field',
-        includeChildren: true,
-        includePartners: false,
-      },
     },
   },
 
@@ -2517,36 +2190,6 @@ export const AddressNL: Story = {
         },
       },
     } satisfies AddressNLComponentSchema,
-    builderInfo: {
-      title: 'Address Field',
-      icon: 'home',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'addressNL',
-        key: 'address',
-        label: 'A Dutch address',
-        validate: {
-          required: false,
-        },
-        deriveAddress: false,
-        layout: 'singleColumn',
-        openForms: {
-          translations: {},
-          components: {
-            postcode: {
-              validate: {pattern: '1015 [a-zA-Z]{2}'},
-              translatedErrors: {},
-            },
-            city: {
-              validate: {pattern: 'Amsterdam'},
-              translatedErrors: {},
-            },
-          },
-        },
-      },
-    },
   },
 
   play: async ({canvasElement, args}) => {
@@ -2598,19 +2241,6 @@ export const Columns: Story = {
       key: 'columns',
       columns: [],
     },
-
-    builderInfo: {
-      title: 'Columns',
-      icon: 'columns',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'columns',
-        key: 'columns',
-        columns: [],
-      },
-    },
   },
 
   play: async ({canvasElement, args, step}) => {
@@ -2656,21 +2286,6 @@ export const FieldSet: Story = {
       label: 'A field set',
       hideHeader: false,
       components: [],
-    },
-
-    builderInfo: {
-      title: 'Field set',
-      icon: 'th-large',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'fieldset',
-        key: 'fieldset',
-        label: 'A field set',
-        hideHeader: false,
-        components: [],
-      },
     },
   },
 
@@ -2737,23 +2352,6 @@ export const EditGrid: Story = {
       groupLabel: 'Group',
       disableAddingRemovingRows: false,
       components: [],
-    },
-
-    builderInfo: {
-      title: 'Repeating group',
-      icon: 'repeat',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'editgrid',
-        key: 'editgrid',
-        label: 'A repeating group',
-        hideLabel: false,
-        groupLabel: 'Group',
-        disableAddingRemovingRows: false,
-        components: [],
-      },
     },
   },
 
@@ -2826,19 +2424,6 @@ export const CosignV1: Story = {
       label: 'A cosign v1',
       authPlugin: 'digid',
     },
-    builderInfo: {
-      title: 'Co-sign (old)',
-      icon: 'id-card-o',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'coSign',
-        key: 'coSign',
-        label: 'A cosign v1',
-        authPlugin: 'digid',
-      },
-    },
   },
 
   play: async ({canvasElement, step, args}) => {
@@ -2881,18 +2466,6 @@ export const CosignV2: Story = {
       type: 'cosign',
       key: 'cosign',
       label: 'A cosign v2',
-    },
-    builderInfo: {
-      title: 'Cosign',
-      icon: 'pen-nib',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'cosign',
-        key: 'cosign',
-        label: 'A cosign v2',
-      },
     },
   },
 
@@ -2955,20 +2528,6 @@ export const Signature: Story = {
       label: 'A signature',
       footer: '',
     },
-
-    builderInfo: {
-      title: 'Signature',
-      icon: 'pencil',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'signature',
-        key: 'signature',
-        label: 'A signature',
-        footer: '',
-      },
-    },
   },
 
   play: async ({canvasElement, step, args}) => {
@@ -3026,19 +2585,6 @@ export const LeafletMap: Story = {
       key: 'map',
       label: 'A map',
     },
-
-    builderInfo: {
-      title: 'Map',
-      icon: 'map',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'map',
-        key: 'map',
-        label: 'A map',
-      },
-    },
   },
 
   play: async ({canvasElement, step, args}) => {
@@ -3094,19 +2640,6 @@ export const Content: Story = {
       type: 'content',
       key: 'content',
       html: '<p>Hello storybook</p>',
-    },
-
-    builderInfo: {
-      title: 'Content',
-      icon: 'html5',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'content',
-        key: 'content',
-        html: '<p>Hello storybook</p>',
-      },
     },
   },
 
@@ -3170,26 +2703,6 @@ export const SoftRequiredErrors: Story = {
         translations: {
           nl: {
             html: '<p>Niet alle velden zijn ingevuld.</p>\n{{ missingFields }}',
-          },
-        },
-      },
-    },
-
-    builderInfo: {
-      title: 'Soft required errors',
-      icon: 'html5',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'softRequiredErrors',
-        key: 'softRequiredErrors',
-        html: '<p>Niet alle velden zijn ingevuld.</p>\n{{ missingFields }}',
-        openForms: {
-          translations: {
-            nl: {
-              html: '<p>Niet alle velden zijn ingevuld.</p>\n{{ missingFields }}',
-            },
           },
         },
       },
@@ -3322,23 +2835,6 @@ export const Profile: Story = {
       description: 'A description for the Profile component',
       shouldUpdateCustomerData: true,
       digitalAddressTypes: ['email', 'phoneNumber'],
-    },
-
-    builderInfo: {
-      title: 'Profile',
-      icon: 'comments',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'customerProfile',
-        key: 'profile',
-        label: 'Profile',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the Profile component',
-        shouldUpdateCustomerData: true,
-        digitalAddressTypes: ['email', 'phoneNumber'],
-      },
     },
   },
 

--- a/src/components/ComponentConfiguration.tsx
+++ b/src/components/ComponentConfiguration.tsx
@@ -30,7 +30,6 @@ export type ComponentConfigurationProps = Omit<MergedProps, 'component'> & {
  * @param options.getFormComponents        Function returning all other Formio components in the builder context.
  * @param options.isNew                    Whether the Formio component is a new component being added or an existing being edited.
  * @param options.component                The (starter) schema of the Formio component being edited.
- * @param options.builderInfo              Meta information from the builder configuration for the Formio component.
  * @param options.onCancel                 Callback to invoke when the 'cancel' button is clicked.
  * @param options.onRemove                 Callback to invoke when the 'remove' button is clicked.
  * @param options.onSubmit                 Callback to invoke when the form is saved. Receives the component
@@ -56,7 +55,6 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
   getAuthPlugins,
   isNew,
   component,
-  builderInfo,
   formType = 'regular',
   onCancel,
   onRemove,
@@ -91,7 +89,6 @@ const ComponentConfiguration: React.FC<ComponentConfigurationProps> = ({
       <ComponentEditForm
         isNew={isNew}
         component={component}
-        builderInfo={builderInfo}
         onCancel={onCancel}
         onRemove={onRemove}
         onSubmit={onSubmit}

--- a/src/components/ComponentConfigurationAppointment.stories.tsx
+++ b/src/components/ComponentConfigurationAppointment.stories.tsx
@@ -8,7 +8,6 @@ import type React from 'react';
 import {fn} from 'storybook/test';
 
 import type {FormType} from '@/context';
-import type {BuilderInfo} from '@/registry/types';
 import {
   DEFAULT_AUTH_PLUGINS,
   DEFAULT_COLORS,
@@ -36,20 +35,6 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-    builderInfo: {
-      title: 'Text field',
-      group: 'basic',
-      icon: 'terminal',
-      schema: {
-        id: 'wekruya',
-        type: 'textfield',
-        key: 'textfield',
-        label: 'A textfield for an appointment form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the textfield component',
-      },
-      weight: 0,
-    },
   },
 } satisfies Meta<typeof ComponentConfiguration>;
 
@@ -66,7 +51,6 @@ interface TemplateArgs {
   prefillAttributes: Record<string, PrefillAttributeOption[]>;
   fileTypes: Array<{value: string; label: string}>;
   isNew: boolean;
-  builderInfo: BuilderInfo<AnyComponentSchema>;
   formType: FormType;
   onCancel: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onRemove: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -86,7 +70,6 @@ const Template: StoryFn<TemplateArgs> = ({
   referenceListsTableItems,
   fileTypes,
   isNew,
-  builderInfo,
   formType,
   onCancel,
   onRemove,
@@ -112,7 +95,6 @@ const Template: StoryFn<TemplateArgs> = ({
     getAuthPlugins={async () => DEFAULT_AUTH_PLUGINS}
     component={component}
     isNew={isNew}
-    builderInfo={builderInfo}
     formType={formType}
     onCancel={onCancel}
     onRemove={onRemove}
@@ -135,20 +117,6 @@ export const Textfield: Story = {
       description: 'A description for the textfield component',
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Text field',
-      group: 'basic',
-      icon: '',
-      schema: {
-        id: 'wekruya',
-        type: 'textfield',
-        key: 'textfield',
-        label: 'A textfield for an appointment form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the textfield component',
-      },
-      weight: 10,
-    },
   },
 };
 
@@ -163,20 +131,6 @@ export const Email: Story = {
       label: 'An email for an appointment form',
       tooltip: 'An example for the tooltip',
       description: 'A description for the email component',
-    },
-    builderInfo: {
-      title: 'Email',
-      group: 'basic',
-      icon: 'at',
-      schema: {
-        id: 'wekruya',
-        type: 'email',
-        key: 'email',
-        label: 'An email for an appointment form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the email component',
-      },
-      weight: 10,
     },
     formType: 'appointment',
   },
@@ -195,21 +149,6 @@ export const NumberField: Story = {
       validate: {
         required: false,
       },
-    },
-    builderInfo: {
-      title: 'Number',
-      group: 'basic',
-      icon: 'hashtag',
-      schema: {
-        id: 'wekruya',
-        type: 'number',
-        key: 'number',
-        label: 'A number field for an appointment form',
-        validate: {
-          required: false,
-        },
-      },
-      weight: 30,
     },
     formType: 'appointment',
   },
@@ -232,23 +171,6 @@ export const Textarea: Story = {
       },
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Textarea',
-      group: 'basic',
-      icon: 'hashtag',
-      schema: {
-        id: 'wekruya',
-        type: 'textarea',
-        key: 'textarea',
-        label: 'A textarea field for an appointment form',
-        autoExpand: false,
-        rows: 3,
-        validate: {
-          required: false,
-        },
-      },
-      weight: 30,
-    },
   },
 };
 
@@ -263,20 +185,6 @@ export const DateField: Story = {
       label: 'A date for an appointment form',
       tooltip: 'An example for the tooltip',
       description: 'A description for the date component',
-    },
-    builderInfo: {
-      title: 'Date Field',
-      icon: 'calendar',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'date',
-        key: 'date',
-        label: 'A date for an appointment form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the date component',
-      },
     },
     formType: 'appointment',
   },
@@ -296,21 +204,6 @@ export const DateTimeField: Story = {
       },
     },
 
-    builderInfo: {
-      title: 'Date/Time Field',
-      icon: 'calendar-plus',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'datetime',
-        key: 'datetime',
-        label: 'A datetime field for an appointment form',
-        validate: {
-          required: false,
-        },
-      },
-    },
     formType: 'appointment',
   },
 };
@@ -329,21 +222,6 @@ export const TimeField: Story = {
       },
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Time Field',
-      icon: 'clock-o',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'time',
-        key: 'time',
-        label: 'A time field for an appointment form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -362,22 +240,6 @@ export const Postcode: Story = {
       },
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Postcode',
-      icon: 'home',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'postcode',
-        key: 'postcode',
-        label: 'A postcode field for an appointment form',
-        validate: {
-          required: false,
-          pattern: '^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$',
-        },
-      },
-    },
   },
 };
 
@@ -392,18 +254,6 @@ export const PhoneNumber: Story = {
       label: 'A phone number field for an appointment form',
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Phone number',
-      icon: 'phone-square',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'phoneNumber',
-        key: 'phoneNumber',
-        label: 'A phone number field for an appointment form',
-      },
-    },
   },
 };
 
@@ -424,24 +274,6 @@ export const SelectBoxes: Story = {
       defaultValue: {},
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Select Boxes',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'selectboxes',
-        key: 'selectboxes',
-        label: 'A selectboxes field for an appointment form',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [],
-        defaultValue: {},
-      },
-    },
   },
 };
 
@@ -463,25 +295,6 @@ export const Radio: Story = {
       values: [],
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Radio',
-      icon: 'dot-circle-o',
-      group: 'basic',
-      weight: 100,
-      schema: {
-        id: 'wekruya',
-        type: 'radio',
-        key: 'radio',
-        label: 'A radio for an appointment form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the radio component',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [],
-      },
-    },
   },
 };
 
@@ -503,24 +316,6 @@ export const Select: Story = {
       defaultValue: '',
     } satisfies SelectComponentSchema,
     formType: 'appointment',
-    builderInfo: {
-      title: 'Select',
-      icon: 'th-list',
-      group: 'basic',
-      weight: 70,
-      schema: {
-        id: 'wqimsadk',
-        type: 'select',
-        key: 'select',
-        label: 'A select field for an appointment form',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        data: {values: []},
-        defaultValue: '',
-      },
-    },
   },
 };
 
@@ -538,21 +333,6 @@ export const BSN: Story = {
       },
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'BSN Field',
-      icon: 'id-card-o',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'bsn',
-        key: 'bsn',
-        label: 'A BSN field for an appointment form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -572,22 +352,6 @@ export const Checkbox: Story = {
       defaultValue: false,
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Checkbox',
-      icon: 'check-square',
-      group: 'basic',
-      weight: 50,
-      schema: {
-        id: 'wekruya',
-        type: 'checkbox',
-        key: 'checkbox',
-        label: 'A checkbox field for an appointment form',
-        validate: {
-          required: false,
-        },
-        defaultValue: false,
-      },
-    },
   },
 };
 
@@ -606,22 +370,6 @@ export const Currency: Story = {
       },
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Currency',
-      icon: 'eur',
-      group: 'basic',
-      weight: 70,
-      schema: {
-        id: 'wekruya',
-        type: 'currency',
-        currency: 'EUR',
-        key: 'currency',
-        label: 'A currency field for an appointment form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -639,21 +387,6 @@ export const Iban: Story = {
       },
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'IBAN Field',
-      icon: 'wallet',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'iban',
-        key: 'iban',
-        label: 'An IBAN field for an appointment form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -672,22 +405,6 @@ export const LicensePlate: Story = {
       },
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'licenseplate Field',
-      icon: 'wallet',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'licenseplate',
-        key: 'licenseplate',
-        label: 'A license plate field for an appointment form',
-        validate: {
-          required: false,
-          pattern: '^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$',
-        },
-      },
-    },
   },
 };
 
@@ -704,20 +421,6 @@ export const NpFamilyMembers: Story = {
       includePartners: false,
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'NP Family members',
-      icon: 'users',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wqimsadk',
-        type: 'npFamilyMembers',
-        key: 'npFamilyMembers',
-        label: 'An npFamilyMembers field for an appointment form',
-        includeChildren: true,
-        includePartners: false,
-      },
-    },
   },
 };
 
@@ -736,23 +439,6 @@ export const AddressNL: Story = {
       deriveAddress: true,
       layout: 'singleColumn',
     } satisfies AddressNLComponentSchema,
-    builderInfo: {
-      title: 'Address Field',
-      icon: 'home',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'addressNL',
-        key: 'address',
-        label: 'A Dutch address for an appointment form',
-        validate: {
-          required: false,
-        },
-        deriveAddress: true,
-        layout: 'singleColumn',
-      },
-    },
     formType: 'appointment',
   },
 };
@@ -768,18 +454,6 @@ export const LeafletMap: Story = {
       label: 'A map for an appointment form',
     },
     formType: 'appointment',
-    builderInfo: {
-      title: 'Map',
-      icon: 'map',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'map',
-        key: 'map',
-        label: 'A map for an appointment form',
-      },
-    },
   },
 };
 

--- a/src/components/ComponentConfigurationSinglePage.stories.tsx
+++ b/src/components/ComponentConfigurationSinglePage.stories.tsx
@@ -8,7 +8,6 @@ import type React from 'react';
 import {fn} from 'storybook/test';
 
 import type {FormType} from '@/context';
-import type {BuilderInfo} from '@/registry/types';
 import {
   DEFAULT_AUTH_PLUGINS,
   DEFAULT_COLORS,
@@ -36,20 +35,6 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-    builderInfo: {
-      title: 'Text field',
-      group: 'basic',
-      icon: 'terminal',
-      schema: {
-        id: 'wekruya',
-        type: 'textfield',
-        key: 'textfield',
-        label: 'A textfield for a single page form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the textfield component',
-      },
-      weight: 0,
-    },
   },
 } satisfies Meta<typeof ComponentConfiguration>;
 
@@ -66,7 +51,6 @@ interface TemplateArgs {
   prefillAttributes: Record<string, PrefillAttributeOption[]>;
   fileTypes: Array<{value: string; label: string}>;
   isNew: boolean;
-  builderInfo: BuilderInfo<AnyComponentSchema>;
   formType: FormType;
   onCancel: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onRemove: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -86,7 +70,6 @@ const Template: StoryFn<TemplateArgs> = ({
   referenceListsTableItems,
   fileTypes,
   isNew,
-  builderInfo,
   formType,
   onCancel,
   onRemove,
@@ -112,7 +95,6 @@ const Template: StoryFn<TemplateArgs> = ({
     getAuthPlugins={async () => DEFAULT_AUTH_PLUGINS}
     component={component}
     isNew={isNew}
-    builderInfo={builderInfo}
     formType={formType}
     onCancel={onCancel}
     onRemove={onRemove}
@@ -135,20 +117,6 @@ export const Textfield: Story = {
       description: 'A description for the textfield component',
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Text field',
-      group: 'basic',
-      icon: '',
-      schema: {
-        id: 'wekruya',
-        type: 'textfield',
-        key: 'textfield',
-        label: 'A textfield for a single page form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the textfield component',
-      },
-      weight: 10,
-    },
   },
 };
 
@@ -163,20 +131,6 @@ export const Email: Story = {
       label: 'An email for a single page form',
       tooltip: 'An example for the tooltip',
       description: 'A description for the email component',
-    },
-    builderInfo: {
-      title: 'Email',
-      group: 'basic',
-      icon: 'at',
-      schema: {
-        id: 'wekruya',
-        type: 'email',
-        key: 'email',
-        label: 'An email for a single page form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the email component',
-      },
-      weight: 10,
     },
     formType: 'single_step',
   },
@@ -195,21 +149,6 @@ export const NumberField: Story = {
       validate: {
         required: false,
       },
-    },
-    builderInfo: {
-      title: 'Number',
-      group: 'basic',
-      icon: 'hashtag',
-      schema: {
-        id: 'wekruya',
-        type: 'number',
-        key: 'number',
-        label: 'A number field for a single page form',
-        validate: {
-          required: false,
-        },
-      },
-      weight: 30,
     },
     formType: 'single_step',
   },
@@ -232,23 +171,6 @@ export const Textarea: Story = {
       },
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Textarea',
-      group: 'basic',
-      icon: 'hashtag',
-      schema: {
-        id: 'wekruya',
-        type: 'textarea',
-        key: 'textarea',
-        label: 'A textarea field for a single page form',
-        autoExpand: false,
-        rows: 3,
-        validate: {
-          required: false,
-        },
-      },
-      weight: 30,
-    },
   },
 };
 
@@ -263,20 +185,6 @@ export const DateField: Story = {
       label: 'A date for a single page form',
       tooltip: 'An example for the tooltip',
       description: 'A description for the date component',
-    },
-    builderInfo: {
-      title: 'Date Field',
-      icon: 'calendar',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'date',
-        key: 'date',
-        label: 'A date for a single page form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the date component',
-      },
     },
     formType: 'single_step',
   },
@@ -296,21 +204,6 @@ export const DateTimeField: Story = {
       },
     },
 
-    builderInfo: {
-      title: 'Date/Time Field',
-      icon: 'calendar-plus',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'datetime',
-        key: 'datetime',
-        label: 'A datetime field for a single page form',
-        validate: {
-          required: false,
-        },
-      },
-    },
     formType: 'single_step',
   },
 };
@@ -329,21 +222,6 @@ export const TimeField: Story = {
       },
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Time Field',
-      icon: 'clock-o',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'time',
-        key: 'time',
-        label: 'A time field for a single page form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -362,22 +240,6 @@ export const Postcode: Story = {
       },
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Postcode',
-      icon: 'home',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'postcode',
-        key: 'postcode',
-        label: 'A postcode field for a single page form',
-        validate: {
-          required: false,
-          pattern: '^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$',
-        },
-      },
-    },
   },
 };
 
@@ -392,18 +254,6 @@ export const PhoneNumber: Story = {
       label: 'A phone number field for a single page form',
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Phone number',
-      icon: 'phone-square',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'phoneNumber',
-        key: 'phoneNumber',
-        label: 'A phone number field for a single page form',
-      },
-    },
   },
 };
 
@@ -424,24 +274,6 @@ export const SelectBoxes: Story = {
       defaultValue: {},
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Select Boxes',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'selectboxes',
-        key: 'selectboxes',
-        label: 'A selectboxes field for a single page form',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [],
-        defaultValue: {},
-      },
-    },
   },
 };
 
@@ -463,25 +295,6 @@ export const Radio: Story = {
       values: [],
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Radio',
-      icon: 'dot-circle-o',
-      group: 'basic',
-      weight: 100,
-      schema: {
-        id: 'wekruya',
-        type: 'radio',
-        key: 'radio',
-        label: 'A radio for a single page form',
-        tooltip: 'An example for the tooltip',
-        description: 'A description for the radio component',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [],
-      },
-    },
   },
 };
 
@@ -503,24 +316,6 @@ export const Select: Story = {
       defaultValue: '',
     } satisfies SelectComponentSchema,
     formType: 'single_step',
-    builderInfo: {
-      title: 'Select',
-      icon: 'th-list',
-      group: 'basic',
-      weight: 70,
-      schema: {
-        id: 'wqimsadk',
-        type: 'select',
-        key: 'select',
-        label: 'A select field for a single page form',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        data: {values: []},
-        defaultValue: '',
-      },
-    },
   },
 };
 
@@ -538,21 +333,6 @@ export const BSN: Story = {
       },
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'BSN Field',
-      icon: 'id-card-o',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'bsn',
-        key: 'bsn',
-        label: 'A BSN field for a single page form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -572,22 +352,6 @@ export const Checkbox: Story = {
       defaultValue: false,
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Checkbox',
-      icon: 'check-square',
-      group: 'basic',
-      weight: 50,
-      schema: {
-        id: 'wekruya',
-        type: 'checkbox',
-        key: 'checkbox',
-        label: 'A checkbox field for a single page form',
-        validate: {
-          required: false,
-        },
-        defaultValue: false,
-      },
-    },
   },
 };
 
@@ -606,22 +370,6 @@ export const Currency: Story = {
       },
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Currency',
-      icon: 'eur',
-      group: 'basic',
-      weight: 70,
-      schema: {
-        id: 'wekruya',
-        type: 'currency',
-        currency: 'EUR',
-        key: 'currency',
-        label: 'A currency field for a single page form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -636,20 +384,6 @@ export const Signature: Story = {
       key: 'signature',
       label: 'A signature field for a single page form',
       footer: '',
-    },
-
-    builderInfo: {
-      title: 'Signature',
-      icon: 'pencil',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'signature',
-        key: 'signature',
-        label: 'A signature field for a single page form',
-        footer: '',
-      },
     },
   },
 };
@@ -668,21 +402,6 @@ export const Iban: Story = {
       },
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'IBAN Field',
-      icon: 'wallet',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'iban',
-        key: 'iban',
-        label: 'An IBAN field for a single page form',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
 };
 
@@ -701,22 +420,6 @@ export const LicensePlate: Story = {
       },
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'licenseplate Field',
-      icon: 'wallet',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'licenseplate',
-        key: 'licenseplate',
-        label: 'A license plate field for a single page form',
-        validate: {
-          required: false,
-          pattern: '^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$',
-        },
-      },
-    },
   },
 };
 
@@ -735,23 +438,6 @@ export const AddressNL: Story = {
       deriveAddress: true,
       layout: 'singleColumn',
     } satisfies AddressNLComponentSchema,
-    builderInfo: {
-      title: 'Address Field',
-      icon: 'home',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'addressNL',
-        key: 'address',
-        label: 'A Dutch address for a single page form',
-        validate: {
-          required: false,
-        },
-        deriveAddress: true,
-        layout: 'singleColumn',
-      },
-    },
     formType: 'single_step',
   },
 };
@@ -767,18 +453,6 @@ export const LeafletMap: Story = {
       label: 'A map for a single page form',
     },
     formType: 'single_step',
-    builderInfo: {
-      title: 'Map',
-      icon: 'map',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'map',
-        key: 'map',
-        label: 'A map for a single page form',
-      },
-    },
   },
 };
 
@@ -795,21 +469,6 @@ export const FieldSet: Story = {
       hideHeader: false,
       components: [],
     },
-
-    builderInfo: {
-      title: 'Field set',
-      icon: 'th-large',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'fieldset',
-        key: 'fieldset',
-        label: 'A field set for a single page form',
-        hideHeader: false,
-        components: [],
-      },
-    },
   },
 };
 
@@ -824,19 +483,6 @@ export const Columns: Story = {
       key: 'columns',
       columns: [],
     },
-
-    builderInfo: {
-      title: 'Columns',
-      icon: 'columns',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'columns',
-        key: 'columns',
-        columns: [],
-      },
-    },
   },
 };
 
@@ -850,19 +496,6 @@ export const Content: Story = {
       type: 'content',
       key: 'content',
       html: '<p>Hello storybook</p>',
-    },
-
-    builderInfo: {
-      title: 'Content',
-      icon: 'html5',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'content',
-        key: 'content',
-        html: '<p>Hello storybook</p>',
-      },
     },
   },
 };
@@ -881,23 +514,6 @@ export const EditGrid: Story = {
       groupLabel: 'Group',
       disableAddingRemovingRows: false,
       components: [],
-    },
-
-    builderInfo: {
-      title: 'Repeating group',
-      icon: 'repeat',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'editgrid',
-        key: 'editgrid',
-        label: 'A repeating group for a single page form',
-        hideLabel: false,
-        groupLabel: 'Group',
-        disableAddingRemovingRows: false,
-        components: [],
-      },
     },
   },
 };

--- a/src/components/ComponentEditForm.spec.tsx
+++ b/src/components/ComponentEditForm.spec.tsx
@@ -28,20 +28,6 @@ test('Mutating components after save does not mutate default values', async () =
           hideHeader: false,
         } satisfies FieldsetComponentSchema
       }
-      builderInfo={{
-        title: 'foo',
-        group: 'bar',
-        icon: 'baz',
-        schema: {
-          id: 'fieldset',
-          type: 'fieldset',
-          key: 'fieldset',
-          label: 'Field set',
-          components: [],
-          hideHeader: false,
-        },
-        weight: 10,
-      }}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={component => (savedComponent = component)}

--- a/src/components/ComponentEditForm.stories.tsx
+++ b/src/components/ComponentEditForm.stories.tsx
@@ -18,7 +18,6 @@ type Story = StoryObj<typeof ComponentEditForm>;
 const render: StoryFn<typeof ComponentEditForm> = ({
   isNew,
   component,
-  builderInfo,
   onCancel,
   onRemove,
   onSubmit,
@@ -26,7 +25,6 @@ const render: StoryFn<typeof ComponentEditForm> = ({
   <ComponentEditForm
     isNew={isNew}
     component={component}
-    builderInfo={builderInfo}
     onCancel={onCancel}
     onRemove={onRemove}
     onSubmit={onSubmit}
@@ -43,18 +41,6 @@ export const Default: Story = {
       type: 'textfield',
       label: 'Text field',
       key: 'textField',
-    },
-    builderInfo: {
-      title: 'Text field',
-      group: 'basic',
-      icon: 'terminal',
-      schema: {
-        id: 'wekruya',
-        type: 'textfield',
-        label: 'Text field',
-        key: 'textField',
-      },
-      weight: 0,
     },
   },
 };

--- a/src/components/ComponentEditForm.tsx
+++ b/src/components/ComponentEditForm.tsx
@@ -8,14 +8,12 @@ import {toFormikValidationSchema} from 'zod-formik-adapter';
 
 import {BuilderContext} from '@/context';
 import {getRegistryEntry} from '@/registry';
-import type {BuilderInfo} from '@/registry/types';
 
 import GenericComponentPreview from './ComponentPreview';
 
 export interface ComponentEditFormProps {
   isNew: boolean;
   component: AnyComponentSchema;
-  builderInfo: BuilderInfo<AnyComponentSchema>;
   onCancel: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onRemove: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onSubmit: (component: AnyComponentSchema) => void;
@@ -53,7 +51,6 @@ const ButtonRow: React.FC<ButtonRowProps> = ({onSubmit, onCancel, onRemove}) => 
 const ComponentEditForm: React.FC<ComponentEditFormProps> = ({
   isNew,
   component,
-  builderInfo,
   onCancel,
   onRemove,
   onSubmit,
@@ -62,7 +59,7 @@ const ComponentEditForm: React.FC<ComponentEditFormProps> = ({
   const builderContext = useContext(BuilderContext);
 
   const registryEntry = getRegistryEntry(component.type);
-  const {edit: EditForm, editSchema: zodSchema} = registryEntry;
+  const {edit: EditForm, editSchema: zodSchema, builderInfo} = registryEntry;
   const hasPreview = registryEntry.preview.panel !== null;
 
   let initialValues = cloneDeep(component);

--- a/src/components/designer/FormioDefinitionDesigner.tsx
+++ b/src/components/designer/FormioDefinitionDesigner.tsx
@@ -295,22 +295,17 @@ const ComponentEditModal: React.FC<ComponentEditModalProps> = ({
   onSubmit,
   onRemove,
   onClose,
-}) => {
-  const {builderInfo} = getRegistryEntry(component.type);
-
-  return (
-    <Modal isOpen closeModal={onClose}>
-      <ComponentEditForm
-        component={component}
-        isNew={isNew}
-        builderInfo={builderInfo}
-        onSubmit={onSubmit}
-        onRemove={onRemove}
-        onCancel={onClose}
-      />
-    </Modal>
-  );
-};
+}) => (
+  <Modal isOpen closeModal={onClose}>
+    <ComponentEditForm
+      component={component}
+      isNew={isNew}
+      onSubmit={onSubmit}
+      onRemove={onRemove}
+      onCancel={onClose}
+    />
+  </Modal>
+);
 
 interface PlaceholderDragOverlayProps {
   componentType: AnyComponentSchema['type'];

--- a/src/registry/addressNL/edit.stories.ts
+++ b/src/registry/addressNL/edit.stories.ts
@@ -15,21 +15,11 @@ export default {
       type: 'addressNL',
       key: 'address',
       label: 'An address field',
-    },
-    builderInfo: {
-      title: 'Address NL',
-      icon: 'home',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'addressNL',
-        key: 'address',
-        label: 'An address field',
-      },
+      layout: 'singleColumn',
+      deriveAddress: false,
     },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/columns/columns-validation.stories.ts
+++ b/src/registry/columns/columns-validation.stories.ts
@@ -18,19 +18,6 @@ export default {
       key: 'columns',
       columns: [],
     },
-
-    builderInfo: {
-      title: 'Columns',
-      icon: 'columns',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'columns',
-        key: 'columns',
-        columns: [],
-      },
-    },
   },
 } satisfies Meta<typeof ComponentEditForm>;
 

--- a/src/registry/columns/columns.spec.tsx
+++ b/src/registry/columns/columns.spec.tsx
@@ -18,18 +18,6 @@ test('(Added) column width sliders configure the width', async () => {
         key: 'columns',
         columns: [],
       }}
-      builderInfo={{
-        title: 'Columns',
-        icon: 'columns',
-        group: 'layout',
-        weight: 10,
-        schema: {
-          id: 'wekruya',
-          type: 'columns',
-          key: 'columns',
-          columns: [],
-        },
-      }}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={onSubmit}

--- a/src/registry/content/content.stories.ts
+++ b/src/registry/content/content.stories.ts
@@ -31,31 +31,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-
-    builderInfo: {
-      title: 'Content',
-      icon: 'html5',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'content',
-        key: 'content',
-        html: '',
-        openForms: {
-          translations: {
-            nl: {
-              html: '<p>Nederlandse inhoud</p>',
-            },
-            en: {
-              html: '<p>English content</p>',
-            },
-          },
-        },
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/date/date-component.stories.ts
+++ b/src/registry/date/date-component.stories.ts
@@ -21,24 +21,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-
-    builderInfo: {
-      title: 'Date Field',
-      icon: 'calendar',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'date',
-        key: 'date',
-        label: 'A date field',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/datetime/datetime-component.stories.ts
+++ b/src/registry/datetime/datetime-component.stories.ts
@@ -23,24 +23,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-
-    builderInfo: {
-      title: 'Date/Time Field',
-      icon: 'calendar-plus',
-      group: 'basic',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'datetime',
-        key: 'datetime',
-        label: 'A datetime field',
-        validate: {
-          required: false,
-        },
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/file/edit.stories.ts
+++ b/src/registry/file/edit.stories.ts
@@ -29,27 +29,6 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-
-    builderInfo: {
-      title: 'File upload',
-      icon: '',
-      group: 'file',
-      weight: 10,
-      schema: {
-        id: 'kiweljhr',
-        type: 'file',
-        key: 'file',
-        label: 'A file upload',
-        file: {
-          name: '',
-          type: [],
-          allowedTypesLabels: [],
-        },
-        filePattern: '',
-        // @ts-expect-error this is what is actually produced by Formio
-        defaultValue: null,
-      },
-    },
   },
 } satisfies Meta<typeof ComponentEditForm>;
 

--- a/src/registry/file/file-validation.stories.ts
+++ b/src/registry/file/file-validation.stories.ts
@@ -13,11 +13,7 @@ export default {
     isNew: true,
     component: {
       id: 'kiweljhr',
-      storage: 'url',
-      url: '',
       type: 'file',
-      options: {withCredentials: true},
-      webcam: false,
       key: 'file',
       label: 'A file upload',
       file: {
@@ -30,30 +26,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-    builderInfo: {
-      title: 'File upload',
-      icon: '',
-      group: 'file',
-      weight: 10,
-      schema: {
-        id: 'kiweljhr',
-        storage: 'url',
-        url: '',
-        type: 'file',
-        options: {withCredentials: true},
-        webcam: false,
-        key: 'file',
-        label: 'A file upload',
-        file: {
-          name: '',
-          type: [],
-          allowedTypesLabels: [],
-        },
-        filePattern: '',
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/map/map-configuration.stories.ts
+++ b/src/registry/map/map-configuration.stories.ts
@@ -27,21 +27,8 @@ export default {
       key: 'map',
       label: 'A map',
     },
-
-    builderInfo: {
-      title: 'Map',
-      icon: 'map',
-      group: 'advanced',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'map',
-        key: 'map',
-        label: 'A map',
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/radio/radio-referentielijsten.stories.ts
+++ b/src/registry/radio/radio-referentielijsten.stories.ts
@@ -28,26 +28,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-    builderInfo: {
-      title: 'Radio',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'radio',
-        key: 'radio',
-        label: 'A radio field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [{value: '', label: ''}],
-        defaultValue: '',
-      } satisfies RadioComponentSchema,
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/radio/radio-validation.stories.ts
+++ b/src/registry/radio/radio-validation.stories.ts
@@ -23,27 +23,8 @@ export default {
       values: [{value: '', label: ''}],
       defaultValue: '',
     },
-
-    builderInfo: {
-      title: 'Radio',
-      icon: 'dot-circle-o',
-      group: 'basic',
-      weight: 100,
-      schema: {
-        id: 'wqimsadk',
-        type: 'radio',
-        key: 'radio',
-        label: 'A radio field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [{value: '', label: ''}],
-        defaultValue: '',
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 
@@ -90,7 +71,7 @@ export const TranslationsArentRequired: Story = {
       await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
 
       // Check that none of the inputs have a Required error message
-      expect(await editForm.queryByText('Required')).toBeNull();
+      expect(editForm.queryByText('Required')).toBeNull();
     });
   },
 };

--- a/src/registry/select/select-referentielijsten.stories.ts
+++ b/src/registry/select/select-referentielijsten.stories.ts
@@ -17,42 +17,18 @@ export default {
       type: 'select',
       key: 'select',
       label: 'A select field',
-      dataSrc: 'values',
-      dataType: 'string',
       openForms: {
         dataSrc: 'manual',
         translations: {},
       },
       data: {values: [{value: '', label: ''}]},
-      values: [{value: '', label: ''}],
       defaultValue: '',
     },
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-    builderInfo: {
-      title: 'Select',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'select',
-        key: 'select',
-        label: 'A select field',
-        dataSrc: 'values',
-        dataType: 'string',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        data: {values: [{value: '', label: ''}]},
-        values: [{value: '', label: ''}],
-        defaultValue: '',
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/select/select-validation.spec.tsx
+++ b/src/registry/select/select-validation.spec.tsx
@@ -23,18 +23,10 @@ test('Option values and labels are required fields', async () => {
     defaultValue: '',
   };
 
-  const builderInfo = {
-    title: 'Select',
-    icon: 'th-list',
-    group: 'basic',
-    weight: 70,
-    schema: component,
-  };
   contextRender(
     <ComponentEditForm
       isNew
       component={component}
-      builderInfo={builderInfo}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={vi.fn()}
@@ -66,18 +58,10 @@ test('There is always at least one option', async () => {
     defaultValue: '',
   };
 
-  const builderInfo = {
-    title: 'Select',
-    icon: 'th-list',
-    group: 'basic',
-    weight: 70,
-    schema: component,
-  };
   contextRender(
     <ComponentEditForm
       isNew
       component={component}
-      builderInfo={builderInfo}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={onSubmit}
@@ -107,18 +91,10 @@ test('All translations are optional', async () => {
     defaultValue: '',
   };
 
-  const builderInfo = {
-    title: 'Select',
-    icon: 'th-list',
-    group: 'basic',
-    weight: 70,
-    schema: component,
-  };
   contextRender(
     <ComponentEditForm
       isNew
       component={component}
-      builderInfo={builderInfo}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={onSubmit}

--- a/src/registry/select/select.spec.tsx
+++ b/src/registry/select/select.spec.tsx
@@ -24,18 +24,10 @@ test('Switch to multiple sets empty array as default value', async () => {
     defaultValue: '',
   };
 
-  const builderInfo = {
-    title: 'Select',
-    icon: 'th-list',
-    group: 'basic',
-    weight: 70,
-    schema: component,
-  };
   contextRender(
     <ComponentEditForm
       isNew
       component={component}
-      builderInfo={builderInfo}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={onSubmit}
@@ -74,18 +66,10 @@ test('Switch to multiple sets empty array as default value when initial is null'
     defaultValue: null, // This can be set by Formio
   };
 
-  const builderInfo = {
-    title: 'Select',
-    icon: 'th-list',
-    group: 'basic',
-    weight: 70,
-    schema: component,
-  };
   contextRender(
     <ComponentEditForm
       isNew
       component={component}
-      builderInfo={builderInfo}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={onSubmit}
@@ -123,18 +107,10 @@ test('Switch to non multiple sets empty string as default value', async () => {
     multiple: true,
   };
 
-  const builderInfo = {
-    title: 'Select',
-    icon: 'th-list',
-    group: 'basic',
-    weight: 70,
-    schema: component,
-  };
   contextRender(
     <ComponentEditForm
       isNew
       component={component}
-      builderInfo={builderInfo}
       onCancel={vi.fn()}
       onRemove={vi.fn()}
       onSubmit={onSubmit}

--- a/src/registry/selectboxes/selectboxes-referentielijsten.stories.ts
+++ b/src/registry/selectboxes/selectboxes-referentielijsten.stories.ts
@@ -27,26 +27,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-    builderInfo: {
-      title: 'Select',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'selectboxes',
-        key: 'selectboxes',
-        label: 'A selectboxes field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [{value: '', label: ''}],
-        defaultValue: {},
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/selectboxes/selectboxes-validation.stories.ts
+++ b/src/registry/selectboxes/selectboxes-validation.stories.ts
@@ -26,27 +26,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-
-    builderInfo: {
-      title: 'Select Boxes',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'selectboxes',
-        key: 'selectboxes',
-        label: 'A selectboxes field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [{value: '', label: ''}],
-        defaultValue: {},
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 
@@ -103,7 +84,7 @@ export const TranslationsArentRequired: Story = {
       await userEvent.click(canvas.getByRole('tab', {name: 'Translations'}));
 
       // Check that none of the inputs have a Required error message
-      await expect(await editForm.queryByText('Required')).toBeNull();
+      expect(editForm.queryByText('Required')).toBeNull();
     });
   },
 };
@@ -128,30 +109,6 @@ export const MinAndMaxSelectedInitialValues: Story = {
         {label: 'Option 4', value: '4'},
       ],
       defaultValue: {},
-    },
-
-    builderInfo: {
-      title: 'Select Boxes',
-      icon: 'plus-square',
-      group: 'basic',
-      weight: 60,
-      schema: {
-        id: 'wqimsadk',
-        type: 'selectboxes',
-        key: 'selectboxes',
-        label: 'A selectboxes field',
-        openForms: {
-          dataSrc: 'manual',
-          translations: {},
-        },
-        values: [
-          {label: 'Option 1', value: '1'},
-          {label: 'Option 2', value: '2'},
-          {label: 'Option 3', value: '3'},
-          {label: 'Option 4', value: '4'},
-        ],
-        defaultValue: {},
-      },
     },
   },
   play: async ({canvasElement, step}) => {

--- a/src/registry/softRequiredErrors/softRequiredErrors.stories.ts
+++ b/src/registry/softRequiredErrors/softRequiredErrors.stories.ts
@@ -31,31 +31,8 @@ export default {
     onCancel: fn(),
     onRemove: fn(),
     onSubmit: fn(),
-
-    builderInfo: {
-      title: 'Soft required errors',
-      icon: 'html5',
-      group: 'layout',
-      weight: 10,
-      schema: {
-        id: 'wekruya',
-        type: 'softRequiredErrors',
-        key: 'softRequiredErrors',
-        html: '',
-        openForms: {
-          translations: {
-            nl: {
-              html: '<p>Niet alle velden zijn ingevuld.</p>\n{{ missingFields }}',
-            },
-            en: {
-              html: '<p>Not all fields have been filled.</p>\n{{ missingFields }}',
-            },
-          },
-        },
-      },
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/textfield/textfield-component.stories.ts
+++ b/src/registry/textfield/textfield-component.stories.ts
@@ -18,24 +18,8 @@ export default {
         required: false,
       },
     },
-
-    builderInfo: {
-      title: 'Text field',
-      group: 'basic',
-      icon: 'terminal',
-      schema: {
-        id: 'wekruya',
-        type: 'textfield',
-        key: 'textfield',
-        label: 'A text field',
-        validate: {
-          required: false,
-        },
-      },
-      weight: 0,
-    },
   },
-} as Meta<typeof ComponentEditForm>;
+} satisfies Meta<typeof ComponentEditForm>;
 
 type Story = StoryObj<typeof ComponentEditForm>;
 

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -66,11 +66,8 @@ export interface FormDesigner {
 
 export interface BuilderInfo<S extends AnyComponentSchema> {
   title: string;
-  group?: string;
   icon: string;
-  documentation?: string;
   schema: S;
-  weight?: number;
 }
 
 type DefaultValueOf<S> = S extends {defaultValue?: infer D} ? D : never;


### PR DESCRIPTION
Closes #292

This should never be passed as prop anymore because we have all the metadata for our known component types in our component registry, which is the single source of truth.

Note that we can also remove the documentation, weight and group properties from the type since those are unused anyway.