### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 1.0.1 (2026-08-04)
+
+Patch release.
+
+- Aligning translations with the formio-renderer.
+
 ## 1.0.0 (2026-07-29)
 
 Feature release.

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -1322,7 +1322,7 @@
     "originalDefault": "Repeating group"
   },
   "eAmrdi": {
-    "defaultMessage": "Aan het laden...",
+    "defaultMessage": "Laden...",
     "description": "Loading content text",
     "originalDefault": "Loading..."
   },
@@ -1700,7 +1700,7 @@
     "originalDefault": "When this is checked, the map component settings configured in the global configuration will be used."
   },
   "osSl3z": {
-    "defaultMessage": "Stad",
+    "defaultMessage": "Plaats",
     "description": "Label for addressNL city read only result",
     "originalDefault": "City"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-formulieren/formio-builder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-formulieren/formio-builder",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-formulieren/formio-builder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An opinionated Formio webform builder for Open Forms",
   "type": "module",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Some translations didn't align with the formio-renderer project, causing issues when using the two together in the backend project. This patch addresses that issue